### PR TITLE
feat: arm 64 support and using compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 15. and more...
 
 ## Requirements
-* AMD64 VPS (2 vCPU and 2GB RAM recommended)
-* Ubuntu 20.04, 22.04 or 24.04
+
+* AMD64/ARM64 VPS (2 vCPUs and 2GB RAM recommended)
+* Including but not limited to Ubuntu (20.04, 22.04 or 24.04), Debian 10-12 and Fedora
 
 ## Services
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -e
 
 source env_file
 
@@ -13,37 +14,7 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-# Check if lsb_release command exists
-if ! command -v lsb_release &>/dev/null; then
-    echo "lsb_release command not found. Please make sure you are running this script on Ubuntu."
-    exit 1
-fi
-
-# Get Ubuntu release information
-ubuntu_release=$(lsb_release -rs)
-
-# Check if the release is Ubuntu 20.04 or 22.04
-if [[ $ubuntu_release == "20.04" ]]; then
-    echo "Ubuntu 20.04"
-elif [[ $ubuntu_release == "22.04" ]]; then
-    echo "Ubuntu 22.04"
-elif [[ $ubuntu_release == "24.04" ]]; then
-    echo "Ubuntu 24.04"
-else
-    echo "This script is intended to run on Ubuntu 20.04, 22.04 or 24.04."
-    exit 1
-fi
-
-if command_not_exists docker-compose; then
-  echo "install docker and docker-compose"
-  sudo apt update && sudo apt install -y docker.io
-  if [[ $ubuntu_release == "24.04" ]]; then
-      curl -L "https://github.com/docker/compose/releases/download/v2.28.1/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose
-      chmod +x /usr/local/bin/docker-compose
-  else
-      sudo apt install -y docker-compose
-  fi
-fi
+curl -fsSL https://get.docker.com | sh
 
 file_path="env_file"
 if [ -f $file_path ]; then
@@ -61,4 +32,4 @@ echo "IDENTIFIER=$identifier" >> ./env_file
 # setup redeploy cron
 ./setup_cron.sh $REDEPLOY_INTERVAL
 
-docker-compose up -d --build
+docker compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   xray-config:
     build:

--- a/logs.sh
+++ b/logs.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
 
-docker-compose logs --tail 100 $1
+docker compose logs --tail 100 $1

--- a/metric-forwarder/Dockerfile
+++ b/metric-forwarder/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.11.9-bullseye
 
-RUN wget https://github.com/grafana/agent/releases/download/v0.41.0/grafana-agent-0.41.0-1.amd64.deb && \
-    dpkg -i grafana-agent-0.41.0-1.amd64.deb && \
-    rm grafana-agent-0.41.0-1.amd64.deb
+RUN arch=$(uname -m) && arch_name=$( [ "$arch" = "x86_64" ] && echo "amd64" ) || ( [ "$arch" = "aarch64" ] && echo "arm64" ) && \
+    wget -O ga.deb https://github.com/grafana/agent/releases/download/v0.41.0/grafana-agent-0.41.0-1.$arch_name.deb && \
+    dpkg -i ga.deb && \
+    rm ga.deb
 
 COPY requirements.txt requirements.txt
 

--- a/restart.sh
+++ b/restart.sh
@@ -16,5 +16,5 @@ else
     exit;
 fi
 
-docker-compose up -d --build
-docker-compose restart
+docker compose up -d --build
+docker compose restart

--- a/show_configs.sh
+++ b/show_configs.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
 
-docker-compose exec xray-config curl http://localhost:5000/metrics
+docker compose exec xray-config curl http://localhost:5000/metrics

--- a/v2ray-exporter/Dockerfile
+++ b/v2ray-exporter/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.19.1
 
-COPY bin/v2ray-exporter_linux_amd64 /
+RUN apk add --no-cache wget
+RUN wget -O /v2ray-exporter https://github.com/wi1dcard/v2ray-exporter/releases/download/v0.6.0/v2ray-exporter_linux_$( ( [ $(uname -m) = 'x86_64' ] && echo "amd64") || ([ $(uname -m) = "aarch64" ] && echo "arm64" ) )
+RUN chmod +x /v2ray-exporter
+RUN apk del -r wget
 
-CMD ["/v2ray-exporter_linux_amd64", "--v2ray-endpoint", "xray:54321"]
+CMD ["/v2ray-exporter", "--v2ray-endpoint", "xray:54321"]

--- a/xray-config/Dockerfile
+++ b/xray-config/Dockerfile
@@ -1,13 +1,16 @@
+FROM teddysun/xray:1.8.16 AS xray-image
+
 FROM python:3.11.9-alpine3.19
+
 COPY requirements.txt requirements.txt
 
 RUN pip3 install --break-system-packages -r requirements.txt
 
-RUN wget https://github.com/XTLS/Xray-core/releases/download/v1.8.16/Xray-linux-64.zip && \
-     unzip Xray-linux-64.zip && mv ./xray /usr/bin/ && rm README.md LICENSE
+COPY --from=xray-image /usr/bin/xray /usr/bin/xray
 
-RUN wget https://github.com/lilendian0x00/xray-knife/releases/download/v2.12.17/Xray-knife-linux-64.zip && \
-     unzip Xray-knife-linux-64.zip && mv ./xray-knife /usr/bin/
+RUN arch=$(uname -m) && arch_name=$( [ "$arch" = "x86_64" ] && echo "64" ) || ( [ "$arch" = "aarch64" ] && echo "arm64-v8a" ) && \
+    wget -O knife.zip https://github.com/lilendian0x00/xray-knife/releases/download/v2.12.17/Xray-knife-linux-$arch_name.zip && \
+    unzip knife.zip && mv ./xray-knife /usr/bin/
 
 RUN apk add curl openssl wireguard-tools-wg-quick
 


### PR DESCRIPTION
- removes the static binary of v2ray-exporter
- ensures xray, xray-knife, v2ray-exporter and grafana binaries are all appropriate in case the arch is arm64
- installs docker using the convenience script, hence docker compose v2 is installed instead of v1