### PR TITLE
Add fail2ban and firewall setup for enhanced server protection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       driver: "json-file"
       options:
         max-size: "1m"  # Limit log file size to 1 MB
-        max-file: "1"    # Retain up to 3 log files (rotate)
+        max-file: "1"    # Retain up to 1 log file
 
   xray:
     build:
@@ -98,6 +98,16 @@ services:
       - '--collector.pressure'
       - "--web.listen-address=172.17.0.1:9100" # only allow access from host.docker.internal interface
 #      - "--web.listen-address=0.0.0.0:9100" # only allow access from host.docker.internal interface
+
+  fail2ban:
+    image: crazymax/fail2ban:latest
+    container_name: fail2ban
+    restart: always
+    network_mode: host  # Needs to monitor host logs for security
+    privileged: true  # Allows fail2ban to apply firewall rules
+    volumes:
+      - ./fail2ban/jail.local:/etc/fail2ban/jail.local:ro
+      - /var/log:/var/log:ro  # Access to system logs for detecting attacks
 
 volumes:
   acme:

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -1,0 +1,20 @@
+[sshd]
+enabled  = true
+port     = ssh
+filter   = sshd
+logpath  = /var/log/auth.log
+maxretry = 3
+
+[nginx-http-auth]
+enabled  = true
+port     = http,https
+filter   = nginx-http-auth
+logpath  = /var/log/nginx/error.log
+maxretry = 3
+
+[xray]
+enabled  = true
+port     = 443,2053,8443
+filter   = xray
+logpath  = /var/log/xray_access.log
+maxretry = 3

--- a/setup_firewall.sh
+++ b/setup_firewall.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This script sets up a basic firewall using UFW to protect exposed ports.
+
+# Check if UFW is installed; install it if not found
+if ! command -v ufw &> /dev/null
+then
+    echo "UFW not found, installing..."
+    sudo apt-get update && sudo apt-get install -y ufw
+fi
+
+# Enable UFW if not already enabled
+sudo ufw --force enable
+
+# Allow SSH connections
+sudo ufw allow ssh
+
+# Allow necessary ports for xray-core and nginx
+sudo ufw allow 80/tcp      # Nginx HTTP
+sudo ufw allow 443/tcp     # xray-core and Nginx HTTPS
+sudo ufw allow 443/udp
+sudo ufw allow 2053/tcp    # Additional port for nginx/xray-core
+sudo ufw allow 2053/udp
+sudo ufw allow 8443/tcp    # Additional port for nginx/xray-core
+sudo ufw allow 8443/udp
+
+# Set default policies
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+
+echo "Firewall configured successfully."


### PR DESCRIPTION
This PR introduces additional security features to protect the exposed ports for xray-core, nginx, and SSH. The following changes have been made:

1. Fail2ban Service:

A new service named fail2ban has been added to the docker-compose.yml file.

It uses the crazymax/fail2ban:latest image with host networking and privileged mode, allowing it to monitor logs on the host system.

A basic jail.local configuration is provided in the fail2ban directory to protect SSH (monitoring /var/log/auth.log), nginx HTTP authentication (monitoring /var/log/nginx/error.log), and xray (monitoring /var/log/xray_access.log).

2. Firewall Setup Script:

A new script setup_firewall.sh has been added to configure a basic firewall using UFW on the server.

The script checks for UFW, installs it if necessary, enables it, allows essential ports (SSH, HTTP, HTTPS, and additional ports for xray/nginx), and sets default policies to deny incoming traffic while allowing outgoing traffic.

Note: Please ensure that the setup_firewall.sh script is executable. If needed, run chmod +x setup_firewall.sh after merging this PR.

These enhancements are designed to improve the security of the server by protecting critical ports and reducing exposure to potential attacks.

Please review these changes and merge if they meet the project requirements.