### PR TITLE
Better fail2ban

### DIFF
--- a/fail2ban/filter.d/nginx-bad-request.conf
+++ b/fail2ban/filter.d/nginx-bad-request.conf
@@ -9,7 +9,7 @@ failregex = ^<HOST> - \S+ \[\] "(?:GET|POST|PUT|DELETE|HEAD|OPTIONS|TRACE|CONNEC
             ^<HOST> - \S+ \[\] ".*" 400
 
 # Simply ignore any log entry containing NGINX_PATH
-ignoreregex = ^<HOST> - - \[[^\]]+\] "[^"]*/${NGINX_PATH}/[^"]*" \d+
+ignoreregex = ^<HOST> - - \[[^\]]+\] "[^"]*/NGINX_PATH/[^"]*" \d+
 
 datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
               ^[^\[]*\[({DATE})

--- a/fail2ban/jail.d/nginx-bad-request.conf
+++ b/fail2ban/jail.d/nginx-bad-request.conf
@@ -2,7 +2,7 @@
 enabled = true
 filter = nginx-bad-request
 port = 80,2053,8443
-logpath = /var/log/nginx/access.log
+logpath = /var/log/nginx/error.log
 maxretry = 3
 findtime = 600
 bantime = 86400 

--- a/prepare_vm.sh
+++ b/prepare_vm.sh
@@ -259,6 +259,31 @@ configure_ufw() {
     echo "y" | ufw enable >/dev/null 2>&1
 }
 
+
+# Process fail2ban filter with NGINX_PATH
+process_fail2ban_filter() {
+    local filter_file="fail2ban/filter.d/nginx-bad-request.conf"
+    local nginx_path
+    
+    if [ ! -f "$filter_file" ]; then
+        echo "Error: nginx-bad-request.conf not found at $filter_file."
+        return 1
+    fi
+    
+    # Get NGINX_PATH from env_file
+    nginx_path=$(grep -oP '^NGINX_PATH=\K.*' env_file)
+    
+    if [ -z "$nginx_path" ]; then
+        echo "Warning: NGINX_PATH not found in env_file. Using default value."
+        nginx_path="default"
+    fi
+    
+    echo "Setting NGINX_PATH to $nginx_path in nginx-bad-request.conf"
+    
+    # Replace NGINX_PATH in the filter
+    sed -i "s|NGINX_PATH|$nginx_path|g" "$filter_file"
+}
+
 # Main execution
 echo
 echo "Preparing the VM..."
@@ -301,6 +326,9 @@ optimize_ufw
 sleep 0.5
 
 configure_ufw
+sleep 0.5
+
+process_fail2ban_filter
 sleep 0.5
 
 echo

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -205,6 +205,7 @@ if not cf_only:
 DEBUG = os.environ.get('DEBUG', 'disable').lower() in ['enable', 'enabled', 'yes']
 xray_config = {
     "log": {
+        "access": "/var/log/xray_access.log",
         "error": "/var/log/xray_error.log",
         "loglevel": "warn",
         "dnsLog": True if DEBUG else False

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -207,7 +207,7 @@ xray_config = {
     "log": {
         "access": "/var/log/xray_access.log",
         "error": "/var/log/xray_error.log",
-        "loglevel": "warn",
+        "loglevel": "warning",
         "dnsLog": True if DEBUG else False
     },
     "routing": {


### PR DESCRIPTION
1. Ignore regex for `NGINX_PATH` variable in the `fail2ban/nginx-bad-request.conf` filter.
2. `nginx-bad-request` will read from nginx_error instead of nginx_access.
3. Add `xray_access` for future `user_count` graph.