### PR TITLE
Fix/inbounds bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,15 +13,15 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "1m"  # Limit log file size to 1 MB
-        max-file: "1"   # Retain up to 1 log file
+        max-size: "1m"
+        max-file: "1"
 
   xray:
     build:
       context: ./xray
       dockerfile: Dockerfile
     volumes:
-      - "/var/log:/var/log"  # Mount the host log directory to ensure logs are accessible
+      - "/var/log:/var/log"
     cap_add:
       - NET_ADMIN
     restart: always
@@ -34,8 +34,8 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "1m"  # Limit log file size to 1 MB
-        max-file: "3"   # Retain up to 3 log files (rotate)
+        max-size: "1m"
+        max-file: "3"
     ports:
       - "443:443/tcp"
       - "443:443/udp"
@@ -54,6 +54,8 @@ services:
       - "80:80/tcp"
       - "2053:2053/tcp"
       - "2053:2053/udp"
+      - "2083:2083/tcp"
+      - "2083:2083/udp"
       - "8443:8443/tcp"
       - "8443:8443/udp"
     environment:
@@ -79,17 +81,19 @@ services:
       context: ./user-metrics
       dockerfile: Dockerfile
     volumes:
-      - "/var/log:/var/log:ro"  # Mount log directory as read-only
+      - "/var/log:/var/log:ro"
     restart: always
     environment:
       - TZ=UTC
+    depends_on:
+      - xray
     logging:
       driver: "json-file"
       options:
         max-size: "1m"
         max-file: "3"
     ports:
-      - "127.0.0.1:9551:9551"  # Expose only to localhost
+      - "127.0.0.1:9551:9551"
 
   metric-forwarder:
     build:
@@ -107,7 +111,7 @@ services:
   node-exporter:
     image: prom/node-exporter:v1.9.0
     restart: always
-    network_mode: host  # needs to access to the host network interfaces
+    network_mode: host
     volumes:
       - "/proc:/host/proc:ro"
       - "/sys:/host/sys:ro"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -86,8 +86,8 @@ http {
 
     # Vless-HU-TLS Handling. (Both direct and CDN)
     server {
-        listen 2053 ssl;
-        listen [::]:2053 ssl;
+        listen 2053 ssl reuseport;
+        listen [::]:2053 ssl reuseport;
         http2 on;
         
         ssl_certificate /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/fullchain.cer;
@@ -99,12 +99,27 @@ http {
             return 403;
         }
 
-        # Forwards this path requests to xray.
+        # Forwards this path requests to xray (direct).
         location = /${NGINX_PATH} {
             if ($http_upgrade != "websocket") {
                 return 404;
             }
             proxy_pass http://xray:8002;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $host;
+            proxy_redirect off;
+        }
+        
+        # Forwards this path requests to xray (cdn).
+        location = /${NGINX_PATH}/cdn {
+            if ($http_upgrade != "websocket") {
+                return 404;
+            }
+            proxy_pass http://xray:8022;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -142,10 +157,10 @@ http {
 
     # Vless-XHTTP-QUIC Handling.
     server {
-        # Vless-xhttp-quic-direct; Client will connect directly with alpn=h3.
+        # Vless-xhttp-quic-direct; Client will connect directly with alpn=h3,h2 (h2 for fallback when h3 is not available).
         listen 8443 quic reuseport;
         listen [::]:8443 quic reuseport;
-        # Vless-xhttp-quic-CDN; Client will connect to CF with alpn=h3 and CF will connect to VM with h2.
+        # Vless-xhttp-quic-CDN; Client will connect to CF with alpn=h3,h2 (h2 for fallback when h3 is not available) and CF will connect to VM with h2,http1.1.
         listen 8443 ssl reuseport;
         listen [::]:8443 ssl reuseport;
         http2 on;
@@ -164,9 +179,19 @@ http {
             return 403;
         }
 
-        # Forwards this path requests to xray.
+        # Forwards this path requests to xray (direct).
         location /${NGINX_PATH} {
             grpc_pass grpc://xray:8003;
+            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            grpc_read_timeout 315;
+            grpc_send_timeout 5m;
+            client_body_timeout 5m;
+            client_max_body_size 0;
+        }
+        
+        # Forwards this path requests to xray (cdn).
+        location /${NGINX_PATH}/cdn {
+            grpc_pass grpc://xray:8033;
             grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             grpc_read_timeout 315;
             grpc_send_timeout 5m;

--- a/xray-config/inbounds.json
+++ b/xray-config/inbounds.json
@@ -88,12 +88,40 @@
   },
   {
     "name": "vless-hu-tls-cdn",
-    "link": "vless://$config_id@$cf_clean_ip_domain:2053?type=httpupgrade&host=$subdomain&path=%2F$nginx_path&security=tls&fp=randomized&alpn=h2%2Chttp%2F1.1&sni=$subdomain#vless-hu-tls-cdn",
-    "cloudflare": true
+    "link": "vless://$config_id@$cf_clean_ip_domain:2053?type=httpupgrade&host=$subdomain&path=%2F$nginx_path%2Fcdn&security=tls&fp=randomized&alpn=h2%2Chttp%2F1.1&sni=$subdomain#vless-hu-tls-cdn",
+    "cloudflare": true,
+    "inbound": {
+      "tag": "vless-hu-tls-cdn",
+      "listen": "0.0.0.0",
+      "port": 8022,
+      "protocol": "vless",
+      "settings": {
+        "clients": [
+          {
+            "id": "$config_id"
+          }
+        ],
+        "decryption": "none"
+      },
+      "streamSettings": {
+        "network": "httpupgrade",
+        "httpupgradeSettings": {
+          "path": "/$nginx_path/cdn"
+        }
+      },
+      "sniffing": {
+        "enabled": true,
+        "destOverride": [
+          "http",
+          "tls",
+          "quic"
+        ]
+      }
+    }
   },
   {
       "name": "vless-xhttp-quic-direct",
-      "link": "vless://$config_id@$direct_subdomain:8443?type=xhttp&mode=auto&path=%2F$nginx_path&security=tls&fp=randomized&alpn=h3&sni=$direct_subdomain#vless-xhttp-quic-direct",
+      "link": "vless://$config_id@$direct_subdomain:8443?type=xhttp&mode=auto&path=%2F$nginx_path&security=tls&fp=randomized&alpn=h3%2Ch2&sni=$direct_subdomain#vless-xhttp-quic-direct",
       "cloudflare": false,
       "inbound": {
         "tag": "vless-xhttp-quic-direct",
@@ -126,7 +154,35 @@
     },
     {
       "name": "vless-xhttp-quic-cdn",
-      "link": "vless://$config_id@$cf_clean_ip_domain:8443?type=xhttp&mode=auto&path=%2F$nginx_path&security=tls&fp=randomized&alpn=h3&sni=$subdomain#vless-xhttp-quic-cdn",
-      "cloudflare": true
+      "link": "vless://$config_id@$cf_clean_ip_domain:8443?type=xhttp&mode=auto&path=%2F$nginx_path%2Fcdn&security=tls&fp=randomized&alpn=h3%2Ch2&sni=$subdomain#vless-xhttp-quic-cdn",
+      "cloudflare": true,
+      "inbound": {
+        "tag": "vless-xhttp-quic-cdn",
+        "listen": "0.0.0.0",
+        "port": 8033,
+        "protocol": "vless",
+        "settings": {
+          "clients": [
+            {
+              "id": "$config_id"
+            }
+          ],
+          "decryption": "none"
+        },
+        "streamSettings": {
+          "network": "xhttp",
+          "xhttpSettings": {
+            "path": "/$nginx_path/cdn"
+          }
+        },
+        "sniffing": {
+          "enabled": true,
+          "destOverride": [
+            "http",
+            "tls",
+            "quic"
+          ]
+        }
+      }
     }
 ]


### PR DESCRIPTION
1. Separated the CDN and Direct pathing to fix the bug that aggregated both `cdn` and `direct` inbounds in the `xray` tags. 
    - The Direct Path will be `/$NGINX_PATH/`, and the CDN path will be `/$NGINX_PATH/cdn/`.

2. Updated XHTTP ALPN to `h3,h2` to support fallback to `h2` when `h3` is not available.

3. Updated `docker-compose` for `user-metrics` to depend on `xray`.