### PR TITLE
feat(warp): one warp per inbound instead of shared load balancer

### DIFF
--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -446,14 +446,17 @@ class XrayConfig:
         self.warps_ready = False
         self.wg_configs = {}
         warp_active = False
+        active_inbounds = [
+            ib for ib in self.configured_inbounds
+            if "inbound" in ib and "tag" in ib["inbound"]
+        ]
         if self.env_config.get("XRAY_OUTBOUND") == "warp":
             try:
                 self.warps = []
-                self.warps.append(register_warp())
-                sleep(2)
-                self.warps.append(register_warp())
-                sleep(2)
-                self.warps.append(register_warp())
+                for i in range(len(active_inbounds)):
+                    if i > 0:
+                        sleep(2)
+                    self.warps.append(register_warp())
                 self.warps_ready = True
                 warp_active = True
             except Exception as e:
@@ -481,27 +484,17 @@ AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = engage.cloudflareclient.com:2408
 """
 
-            inbound_tags = [
-                ib["inbound"]["tag"]
-                for ib in self.configured_inbounds
-                if "inbound" in ib and "tag" in ib["inbound"]
-            ]
-            self.xray_config["routing"]["rules"].insert(
-                0,
-                {
-                    "inboundTag": inbound_tags,
-                    "balancerTag": "balancer1",
-                },
-            )
-
             self.xray_config["routing"]["domainStrategy"] = "IPOnDemand"
-            self.xray_config["routing"]["balancers"] = [
-                {
-                    "tag": "balancer1",
-                    "selector": ["warp0", "warp1", "warp2"],
-                    "strategy": {"type": "roundRobin"},
-                }
-            ]
+
+            for i, ib in enumerate(active_inbounds):
+                tag = ib["inbound"]["tag"]
+                self.xray_config["routing"]["rules"].insert(
+                    i,
+                    {
+                        "inboundTag": [tag],
+                        "outboundTag": f"warp{i}",
+                    },
+                )
 
             for i, warp in enumerate(self.warps):
                 self.xray_config["outbounds"].append(

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -46,29 +46,25 @@ if [ "$XRAY_OUTBOUND" = "warp" ]; then
   fi
 
   # Extract and save each WireGuard config
-  for iface in wg0 wg1 wg2; do
-      CONFIG_CONTENT=$(echo "$WG_CONFIGS" | jq -r ".\"$iface\" // empty")
-      if [ -n "$CONFIG_CONTENT" ]; then
-          echo "$CONFIG_CONTENT" > "/etc/wireguard/${iface}.conf"
-          if [ "$DEBUG" = "true" ]; then
-              echo "Saved /etc/wireguard/${iface}.conf:"
-              echo "$CONFIG_CONTENT"
-          else
-              echo "Saved /etc/wireguard/${iface}.conf"
-          fi
+  for iface in $(echo "$WG_CONFIGS" | jq -r 'keys[]'); do
+      CONFIG_CONTENT=$(echo "$WG_CONFIGS" | jq -r ".\"$iface\"")
+      echo "$CONFIG_CONTENT" > "/etc/wireguard/${iface}.conf"
+      if [ "$DEBUG" = "true" ]; then
+          echo "Saved /etc/wireguard/${iface}.conf:"
+          echo "$CONFIG_CONTENT"
+      else
+          echo "Saved /etc/wireguard/${iface}.conf"
       fi
   done
 
   # Bring up wg interfaces
-  for i in 0 1 2; do
-      if [ -f "/etc/wireguard/wg$i.conf" ]; then
-          echo "Bringing up wg$i..."
-          /usr/bin/wg-quick up "wg$i" || echo "Warning: Failed to bring up wg$i"
-          
-          MONIT_CONF_PATH="/etc/monit.d/wg$i"
-          cp /wg_monit "$MONIT_CONF_PATH"
-          sed -i "s|\${INTERFACE}|wg$i|g" "$MONIT_CONF_PATH"
-      fi
+  for iface in $(echo "$WG_CONFIGS" | jq -r 'keys[]'); do
+      echo "Bringing up $iface..."
+      /usr/bin/wg-quick up "$iface" || echo "Warning: Failed to bring up $iface"
+
+      MONIT_CONF_PATH="/etc/monit.d/$iface"
+      cp /wg_monit "$MONIT_CONF_PATH"
+      sed -i "s|\${INTERFACE}|$iface|g" "$MONIT_CONF_PATH"
   done
 fi
 


### PR DESCRIPTION


- **Removes** the round-robin load balancer (`balancer1`) that shared 3 fixed WARP accounts across all inbounds
- **Registers** one WARP account per active inbound (instead of always 3)
- **Routes** each inbound directly and exclusively to its own `warpN` outbound / `wgN` WireGuard interface
- **entrypoint.sh** now dynamically iterates over whatever keys exist in the `/wg-configs` response instead of hardcoding `wg0 wg1 wg2`