### PR TITLE
chore: bump deps across all services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       - node-exporter
 
   node-exporter:
-    image: prom/node-exporter:v1.9.1
+    image: prom/node-exporter:v1.11.1
     restart: always
     network_mode: host
     <<: *minimal-perf

--- a/env_file.example
+++ b/env_file.example
@@ -24,7 +24,8 @@ CF_CLEAN_IP_DOMAIN=
 
 XRAY_OUTBOUND=direct
 
-XRAY_INBOUNDS=vless-tcp-tls-direct,vless-hu-tls-direct,vless-xhttp-quic-direct  
+# Append :<count> to create replicas via path-based routing, e.g.: vless-hu-tls-cdn:3
+XRAY_INBOUNDS=vless-tcp-tls-direct,vless-hu-tls-direct,vless-xhttp-quic-direct 
 
 SSL_PROVIDER=letsencrypt
 

--- a/metric-forwarder/Dockerfile
+++ b/metric-forwarder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.2-bullseye
+FROM python:3.14.6-slim-bookworm
 
 RUN \
     # Update apt and install wget
@@ -20,7 +20,8 @@ RUN \
     dpkg -i ga.deb && \
     rm ga.deb && \
     \
-    # Clean apt cache
+    # Remove wget and clean up
+    apt-get purge -y wget && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt

--- a/metric-forwarder/requirements.txt
+++ b/metric-forwarder/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.32.3
-prometheus-client==0.21.1
-PyYAML==6.0.2
-structlog==25.1.0
+requests==2.34.2
+prometheus-client==0.25.0
+PyYAML==6.0.3
+structlog==26.1.0

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.26.3-alpine
 
-RUN apk add curl
+RUN apk add curl jq
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.26.3-alpine
+FROM nginx:1.31.1-alpine-slim
 
 RUN apk add curl jq
 

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -48,6 +48,14 @@ fi
 
 sed -i "s|\${DIRECT_SUBDOMAIN}|$DIRECT_SUBDOMAIN|g" "$NGINX_CONF_PATH"
 
+# Fetch replica location blocks and write include files (empty = no replicas configured)
+LOCATIONS=$(curl -sf "http://xray-config:5000/nginx-locations" 2>/dev/null || echo "{}")
+for port in 2053 8880 8443; do
+    mkdir -p "/etc/nginx/locations.d/$port"
+    printf '%s\n' "$(echo "$LOCATIONS" | jq -r ".\"$port\" // empty")" \
+        > "/etc/nginx/locations.d/$port/replicas.conf"
+done
+
 CERT_FLAG="/var/log/compassvpn/.cert_renewed"
 LAST_FLAG_TIME=""
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -104,7 +104,7 @@ http {
         }
 
         # Forwards this path requests to xray (direct).
-        location = /${NGINX_PATH} {
+        location = /${NGINX_PATH}/1 {
             if ($http_upgrade != "websocket") {
                 return 404;
             }
@@ -117,9 +117,9 @@ http {
             proxy_set_header Host $host;
             proxy_redirect off;
         }
-        
+
         # Forwards this path requests to xray (cdn).
-        location = /${NGINX_PATH}/cdn {
+        location = /${NGINX_PATH}/cdn/1 {
             if ($http_upgrade != "websocket") {
                 return 404;
             }
@@ -132,6 +132,8 @@ http {
             proxy_set_header Host $host;
             proxy_redirect off;
         }
+
+        include /etc/nginx/locations.d/2053/replicas.conf;
 
         # Fallback all other requests to an external website.
         location / {
@@ -170,7 +172,7 @@ http {
         }
 
         # Forwards this path requests to xray (direct).
-        location /${NGINX_PATH} {
+        location /${NGINX_PATH}/1 {
             proxy_pass http://xray:8004;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -183,7 +185,7 @@ http {
         }
 
         # Forwards this path requests to xray (cdn).
-        location /${NGINX_PATH}/cdn {
+        location /${NGINX_PATH}/cdn/1 {
             proxy_pass http://xray:8044;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -194,6 +196,8 @@ http {
             proxy_buffering off;
             proxy_read_timeout 315;
         }
+
+        include /etc/nginx/locations.d/8880/replicas.conf;
 
         # Fallback all other requests to an external website.
         location / {
@@ -245,7 +249,7 @@ http {
         }
 
         # Forwards this path requests to xray (direct).
-        location /${NGINX_PATH} {
+        location /${NGINX_PATH}/1 {
             grpc_pass grpc://xray:8003;
             grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             grpc_read_timeout 315;
@@ -253,9 +257,9 @@ http {
             client_body_timeout 5m;
             client_max_body_size 0;
         }
-        
+
         # Forwards this path requests to xray (cdn).
-        location /${NGINX_PATH}/cdn {
+        location /${NGINX_PATH}/cdn/1 {
             grpc_pass grpc://xray:8033;
             grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             grpc_read_timeout 315;
@@ -264,6 +268,8 @@ http {
             client_max_body_size 0;
         }
         
+        include /etc/nginx/locations.d/8443/replicas.conf;
+
         # Fallback all other requests to an external website.
         location / {
             sub_filter $proxy_host $host;

--- a/xray-config/Dockerfile
+++ b/xray-config/Dockerfile
@@ -1,6 +1,6 @@
-FROM teddysun/xray:25.6.8 AS xray-image
+FROM teddysun/xray:26.3.27 AS xray-image
 
-FROM python:3.13.2-alpine3.21
+FROM python:3.14.6-alpine3.24
 
 COPY requirements.txt requirements.txt
 

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -1,7 +1,10 @@
+import copy
 import json
+import re
 import string
 from time import sleep
 from typing import Any, Dict, List, Optional
+from urllib.parse import unquote, quote
 import requests
 
 from shared_lib.network import get_public_ip
@@ -17,6 +20,102 @@ from shared_lib.paths import (
 )
 
 
+# Inbounds that bind a port directly (no HTTP path) — replicas not supported
+_NO_REPLICA_SUPPORT = {"vless-tcp-tls-direct", "vmess-ws-cdn"}
+
+# Maps inbound name → (nginx server port, location template)
+_NGINX_PROXY_MAP: Dict[str, tuple] = {
+    "vless-hu-tls-direct":     (2053, "hu"),
+    "vless-hu-tls-cdn":        (2053, "hu"),
+    "vless-xhttp-direct":      (8880, "xhttp"),
+    "vless-xhttp-cdn":         (8880, "xhttp"),
+    "vless-xhttp-quic-direct": (8443, "xhttp_quic"),
+    "vless-xhttp-quic-cdn":    (8443, "xhttp_quic"),
+}
+
+_STREAM_PATH_KEY = {
+    "ws":          "wsSettings",
+    "httpupgrade": "httpupgradeSettings",
+    "xhttp":       "xhttpSettings",
+}
+
+
+def _make_replica(inbound_def: Dict[str, Any], replica_index: int, new_port: int) -> Dict[str, Any]:
+    replica = copy.deepcopy(inbound_def)
+    suffix = f"/{replica_index}"
+
+    replica["inbound"]["tag"] += f"-{replica_index}"
+    replica["inbound"]["port"] = new_port
+
+    stream = replica["inbound"].get("streamSettings", {})
+    sk = _STREAM_PATH_KEY.get(stream.get("network", ""))
+    if sk and sk in stream:
+        stream[sk]["path"] += suffix
+
+    link = replica.get("link")
+    if isinstance(link, dict):
+        if "path" in link:
+            link["path"] += suffix
+        if "ps" in link:
+            link["ps"] += f"-{replica_index}"
+    elif isinstance(link, str):
+        replica["link"] = re.sub(
+            r"path=([^&#]+)",
+            lambda m: f"path={quote(unquote(m.group(1)) + suffix, safe='')}",
+            link,
+        )
+        replica["link"] = re.sub(
+            r"#(.+)$",
+            lambda m: f"#{m.group(1)}-{replica_index}",
+            replica["link"],
+        )
+
+    return replica
+
+
+def _nginx_location_block(path: str, xray_port: int, template: str) -> str:
+    if template == "hu":
+        return (
+            f'    location = {path} {{\n'
+            f'        if ($http_upgrade != "websocket") {{ return 404; }}\n'
+            f'        proxy_pass http://xray:{xray_port};\n'
+            f'        proxy_http_version 1.1;\n'
+            f'        proxy_set_header Upgrade $http_upgrade;\n'
+            f'        proxy_set_header Connection "upgrade";\n'
+            f'        proxy_set_header X-Real-IP $remote_addr;\n'
+            f'        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
+            f'        proxy_set_header Host $host;\n'
+            f'        proxy_redirect off;\n'
+            f'    }}'
+        )
+    if template == "xhttp":
+        return (
+            f'    location {path} {{\n'
+            f'        proxy_pass http://xray:{xray_port};\n'
+            f'        proxy_http_version 1.1;\n'
+            f'        proxy_set_header Host $host;\n'
+            f'        proxy_set_header X-Real-IP $remote_addr;\n'
+            f'        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
+            f'        proxy_set_header Upgrade $http_upgrade;\n'
+            f'        proxy_set_header Connection $connection_upgrade;\n'
+            f'        proxy_buffering off;\n'
+            f'        proxy_read_timeout 315;\n'
+            f'    }}'
+        )
+    if template == "xhttp_quic":
+        return (
+            f'    location {path} {{\n'
+            f'        grpc_pass grpc://xray:{xray_port};\n'
+            f'        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
+            f'        grpc_read_timeout 315;\n'
+            f'        grpc_send_timeout 5m;\n'
+            f'        client_body_timeout 5m;\n'
+            f'        client_max_body_size 0;\n'
+            f'    }}'
+        )
+    return ""
+
+
 class XrayConfig:
     def __init__(self) -> None:
         """Initialize instance attributes to hold shared variables."""
@@ -27,7 +126,7 @@ class XrayConfig:
         self.cf_api_token: Optional[str] = None
         self.cf_zone_id: Optional[str] = None
         self.nginx_path: Optional[str] = None
-        self.xray_inbounds: List[str] = []
+        self.xray_inbounds: Dict[str, int] = {}
         self.server_ip: str = "Unknown"
         self.domain: Optional[str] = None
         self.subdomain: Optional[str] = None
@@ -40,6 +139,7 @@ class XrayConfig:
         self.warps_ready: bool = False
         self.wg_configs: Dict[str, str] = {}
         self.warps: List[Dict[str, Any]] = []
+        self.nginx_locations: Dict[int, str] = {}
         self.initialized: bool = False
 
     def _get_domain(self) -> None:
@@ -163,10 +263,13 @@ class XrayConfig:
         self.cf_api_token = self.env_config.get("CF_API_TOKEN")
         self.cf_zone_id = self.env_config.get("CF_ZONE_ID")
         self.nginx_path = self.env_config.get("NGINX_PATH")
-        self.xray_inbounds = self.env_config.get(
+        self.xray_inbounds = {}
+        for entry in self.env_config.get(
             "XRAY_INBOUNDS",
             "vmess-ws-cdn,vless-tcp-tls-direct,vless-hu-tls-direct,vless-hu-tls-cdn,vless-xhttp-quic-direct,vless-xhttp-quic-cdn,vless-xhttp-direct,vless-xhttp-cdn",
-        ).split(",")
+        ).split(","):
+            name, _, count = entry.strip().partition(":")
+            self.xray_inbounds[name] = int(count) if count.isdigit() else 1
 
         log.debug(
             "CF Config",
@@ -312,10 +415,36 @@ class XrayConfig:
                 },
             )
             self.configured_inbounds = [
-                inbound
-                for inbound in all_inbounds
-                if inbound.get("name") in self.xray_inbounds
+                ib for ib in all_inbounds if ib.get("name") in self.xray_inbounds
             ]
+
+            # Expand replicas (before vmess link encoding so dict links are still patchable).
+            # Indices start at 1: replica 1 keeps the original port (matched by static
+            # nginx location blocks), replicas 2+ get ports from the 9000+ pool.
+            expanded: List[Dict[str, Any]] = []
+            _replica_port = 9000
+            for ib in self.configured_inbounds:
+                name = ib.get("name", "")
+                count = self.xray_inbounds.get(name, 1)
+                if name in _NO_REPLICA_SUPPORT and count > 1:
+                    log.warning(
+                        f"{name} does not support replicas; capped at 1",
+                        hypothesisId="CFG",
+                    )
+                    count = 1
+                for idx in range(1, count + 1):
+                    port = ib["inbound"]["port"] if idx == 1 else _replica_port
+                    if idx > 1:
+                        _replica_port += 1
+                    replica = _make_replica(ib, idx, port)
+                    replica["_replica_index"] = idx
+                    if name in _NGINX_PROXY_MAP:
+                        replica["_nginx_port"], replica["_nginx_template"] = _NGINX_PROXY_MAP[name]
+                    expanded.append(replica)
+                if count > 1:
+                    log.info(f"{name}: {count} replicas configured", hypothesisId="CFG")
+            self.configured_inbounds = expanded
+
             for inbound in self.configured_inbounds:
                 if isinstance(inbound.get("link"), dict):
                     inbound["link"] = generate_vmess_link(inbound["link"])
@@ -344,6 +473,18 @@ class XrayConfig:
                 f"Skipped {skipped} TLS inbound(s) with missing certificates",
                 hypothesisId="CFG",
             )
+
+        # Build nginx location blocks for replicas that survived TLS filtering
+        nginx_locs: Dict[int, List[str]] = {}
+        for ib in self.configured_inbounds:
+            if ib.get("_replica_index", 0) > 1 and "_nginx_port" in ib:
+                stream = ib["inbound"].get("streamSettings", {})
+                sk = _STREAM_PATH_KEY.get(stream.get("network", ""))
+                path = stream.get(sk, {}).get("path", "") if sk else ""
+                if path:
+                    block = _nginx_location_block(path, ib["inbound"]["port"], ib["_nginx_template"])
+                    nginx_locs.setdefault(ib["_nginx_port"], []).append(block)
+        self.nginx_locations = {port: "\n\n".join(blocks) for port, blocks in nginx_locs.items()}
 
         inbounds_list = [
             {
@@ -528,10 +669,7 @@ Endpoint = engage.cloudflareclient.com:2408
             {"tag": "blocked", "protocol": "blackhole", "settings": {}}
         ]
 
-        active_inbound_count = len(
-            [ib for ib in self.configured_inbounds if "inbound" in ib]
-        )
-        if active_inbound_count == 0:
+        if not active_inbounds:
             log.warning(
                 "No user-facing inbounds are active. "
                 "Clients will not be able to connect. "
@@ -539,8 +677,9 @@ Endpoint = engage.cloudflareclient.com:2408
                 hypothesisId="CFG",
             )
         else:
+            tags = [ib["inbound"]["tag"] for ib in active_inbounds]
             log.info(
-                f"Initialized with {active_inbound_count} active inbound(s)",
+                f"Initialized with {len(active_inbounds)} active inbound(s): {', '.join(tags)}",
                 hypothesisId="CFG",
             )
 

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -446,14 +446,17 @@ class XrayConfig:
         self.warps_ready = False
         self.wg_configs = {}
         warp_active = False
+        active_inbounds = [
+            ib for ib in self.configured_inbounds
+            if "inbound" in ib and "tag" in ib["inbound"]
+        ]
         if self.env_config.get("XRAY_OUTBOUND") == "warp":
             try:
                 self.warps = []
-                self.warps.append(register_warp())
-                sleep(2)
-                self.warps.append(register_warp())
-                sleep(2)
-                self.warps.append(register_warp())
+                for i in range(len(active_inbounds)):
+                    if i > 0:
+                        sleep(2)
+                    self.warps.append(register_warp())
                 self.warps_ready = True
                 warp_active = True
             except Exception as e:
@@ -481,27 +484,17 @@ AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = engage.cloudflareclient.com:2408
 """
 
-            inbound_tags = [
-                ib["inbound"]["tag"]
-                for ib in self.configured_inbounds
-                if "inbound" in ib and "tag" in ib["inbound"]
-            ]
-            self.xray_config["routing"]["rules"].insert(
-                0,
-                {
-                    "inboundTag": inbound_tags,
-                    "balancerTag": "balancer1",
-                },
-            )
-
             self.xray_config["routing"]["domainStrategy"] = "IPOnDemand"
-            self.xray_config["routing"]["balancers"] = [
-                {
-                    "tag": "balancer1",
-                    "selector": ["warp0", "warp1", "warp2"],
-                    "strategy": {"type": "roundRobin"},
-                }
-            ]
+
+            for i, ib in enumerate(active_inbounds):
+                tag = ib["inbound"]["tag"]
+                self.xray_config["routing"]["rules"].insert(
+                    i,
+                    {
+                        "inboundTag": [tag],
+                        "outboundTag": f"warp{i}",
+                    },
+                )
 
             for i, warp in enumerate(self.warps):
                 self.xray_config["outbounds"].append(

--- a/xray-config/inbounds.json
+++ b/xray-config/inbounds.json
@@ -49,7 +49,7 @@
   },
   {
     "name": "vless-tcp-tls-direct",
-    "link": "vless://$config_id@$direct_subdomain:443?type=tcp&security=tls&flow=xtls-rprx-vision&fp=randomized&alpn=h2%2Chttp%2F1.1&sni=$direct_subdomain#vless-tcp-tls-direct",
+    "link": "vless://$config_id@$direct_subdomain:443?type=tcp&security=tls&flow=xtls-rprx-vision&fp=chrome&alpn=h2%2Chttp%2F1.1&sni=$direct_subdomain#vless-tcp-tls-direct",
     "cloudflare": false,
     "inbound": {
       "tag": "vless-tcp-tls-direct",
@@ -103,7 +103,7 @@
   },
   {
     "name": "vless-hu-tls-direct",
-    "link": "vless://$config_id@$direct_subdomain:2053?type=httpupgrade&host=$direct_subdomain&path=%2F$nginx_path&security=tls&fp=randomized&alpn=h2%2Chttp%2F1.1&sni=$direct_subdomain#vless-hu-tls-direct",
+    "link": "vless://$config_id@$direct_subdomain:2053?type=httpupgrade&host=$direct_subdomain&path=%2F$nginx_path&security=tls&fp=chrome&alpn=h2%2Chttp%2F1.1&sni=$direct_subdomain#vless-hu-tls-direct",
     "cloudflare": false,
     "inbound": {
       "tag": "vless-hu-tls-direct",
@@ -136,7 +136,7 @@
   },
   {
     "name": "vless-hu-tls-cdn",
-    "link": "vless://$config_id@$cf_clean_ip_domain:2053?type=httpupgrade&host=$subdomain&path=%2F$nginx_path%2Fcdn&security=tls&fp=randomized&alpn=h2%2Chttp%2F1.1&sni=$subdomain#vless-hu-tls-cdn",
+    "link": "vless://$config_id@$cf_clean_ip_domain:2053?type=httpupgrade&host=$subdomain&path=%2F$nginx_path%2Fcdn&security=tls&fp=chrome&alpn=h2%2Chttp%2F1.1&sni=$subdomain#vless-hu-tls-cdn",
     "cloudflare": true,
     "inbound": {
       "tag": "vless-hu-tls-cdn",
@@ -169,7 +169,7 @@
   },
   {
       "name": "vless-xhttp-quic-direct",
-      "link": "vless://$config_id@$direct_subdomain:8443?type=xhttp&mode=auto&path=%2F$nginx_path&security=tls&fp=randomized&alpn=h3&sni=$direct_subdomain#vless-xhttp-quic-direct",
+      "link": "vless://$config_id@$direct_subdomain:8443?type=xhttp&mode=auto&path=%2F$nginx_path&security=tls&fp=chrome&alpn=h3&sni=$direct_subdomain#vless-xhttp-quic-direct",
       "cloudflare": false,
       "inbound": {
         "tag": "vless-xhttp-quic-direct",
@@ -203,7 +203,7 @@
     },
     {
       "name": "vless-xhttp-quic-cdn",
-      "link": "vless://$config_id@$cf_clean_ip_domain:8443?type=xhttp&mode=auto&path=%2F$nginx_path%2Fcdn&security=tls&fp=randomized&alpn=h3&sni=$subdomain#vless-xhttp-quic-cdn",
+      "link": "vless://$config_id@$cf_clean_ip_domain:8443?type=xhttp&mode=auto&path=%2F$nginx_path%2Fcdn&security=tls&fp=chrome&alpn=h3&sni=$subdomain#vless-xhttp-quic-cdn",
       "cloudflare": true,
       "inbound": {
         "tag": "vless-xhttp-quic-cdn",

--- a/xray-config/requirements.txt
+++ b/xray-config/requirements.txt
@@ -1,3 +1,3 @@
-Flask==3.1.0
-requests==2.32.3
-structlog==25.1.0
+Flask==3.1.3
+requests==2.34.2
+structlog==26.1.0

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -55,6 +55,12 @@ class XrayService:
                 abort(404)
             return json.dumps(config.wg_configs, indent=4)
 
+        @self.app.route("/nginx-locations")
+        def get_nginx_locations():
+            if not config.initialized:
+                return "Not Ready", 503
+            return json.dumps(config.nginx_locations, indent=4)
+
         @self.app.route("/metrics")
         def metrics():
             return self.latest_metrics

--- a/xray-exporter/Dockerfile
+++ b/xray-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.1
+FROM alpine:3.22.4
 
 RUN apk add --no-cache wget && \
     ARCH=$(uname -m) && \

--- a/xray/Dockerfile
+++ b/xray/Dockerfile
@@ -1,4 +1,4 @@
-FROM teddysun/xray:25.6.8
+FROM teddysun/xray:26.3.27
 
 RUN apk update && apk add curl wget wireguard-tools-wg-quick monit jq net-tools
 

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -46,29 +46,25 @@ if [ "$XRAY_OUTBOUND" = "warp" ]; then
   fi
 
   # Extract and save each WireGuard config
-  for iface in wg0 wg1 wg2; do
-      CONFIG_CONTENT=$(echo "$WG_CONFIGS" | jq -r ".\"$iface\" // empty")
-      if [ -n "$CONFIG_CONTENT" ]; then
-          echo "$CONFIG_CONTENT" > "/etc/wireguard/${iface}.conf"
-          if [ "$DEBUG" = "true" ]; then
-              echo "Saved /etc/wireguard/${iface}.conf:"
-              echo "$CONFIG_CONTENT"
-          else
-              echo "Saved /etc/wireguard/${iface}.conf"
-          fi
+  for iface in $(echo "$WG_CONFIGS" | jq -r 'keys[]'); do
+      CONFIG_CONTENT=$(echo "$WG_CONFIGS" | jq -r ".\"$iface\"")
+      echo "$CONFIG_CONTENT" > "/etc/wireguard/${iface}.conf"
+      if [ "$DEBUG" = "true" ]; then
+          echo "Saved /etc/wireguard/${iface}.conf:"
+          echo "$CONFIG_CONTENT"
+      else
+          echo "Saved /etc/wireguard/${iface}.conf"
       fi
   done
 
   # Bring up wg interfaces
-  for i in 0 1 2; do
-      if [ -f "/etc/wireguard/wg$i.conf" ]; then
-          echo "Bringing up wg$i..."
-          /usr/bin/wg-quick up "wg$i" || echo "Warning: Failed to bring up wg$i"
-          
-          MONIT_CONF_PATH="/etc/monit.d/wg$i"
-          cp /wg_monit "$MONIT_CONF_PATH"
-          sed -i "s|\${INTERFACE}|wg$i|g" "$MONIT_CONF_PATH"
-      fi
+  for iface in $(echo "$WG_CONFIGS" | jq -r 'keys[]'); do
+      echo "Bringing up $iface..."
+      /usr/bin/wg-quick up "$iface" || echo "Warning: Failed to bring up $iface"
+
+      MONIT_CONF_PATH="/etc/monit.d/$iface"
+      cp /wg_monit "$MONIT_CONF_PATH"
+      sed -i "s|\${INTERFACE}|$iface|g" "$MONIT_CONF_PATH"
   done
 fi
 


### PR DESCRIPTION

- **metric-forwarder**: Python `3.13.2-bullseye` → `3.14.6-slim-bookworm`; fix grafana-agent download URL (v0.44.3 had no assets, pinned back to v0.44.2); purge `wget` after install to reduce image size
- **metric-forwarder deps**: `requests` 2.32.3→2.34.2, `prometheus-client` 0.21.1→0.25.0, `PyYAML` 6.0.2→6.0.3, `structlog` 25.1.0→26.1.0
- **xray / xray-config**: `teddysun/xray` 25.6.8→26.3.27
- **xray-config**: Python `3.13.2-alpine3.21` → `3.14.6-alpine3.24`
- **xray-config deps**: `Flask` 3.1.0→3.1.3, `requests` 2.32.3→2.34.2, `structlog` 25.1.0→26.1.0
- **xray-exporter**: Alpine `3.22.1` → `3.22.4`
- **nginx**: `1.26.3-alpine` → `1.31.1-alpine-slim`
- **docker-compose**: `node-exporter` v1.9.1→v1.11.1

Not included (separate tasks): grafana-agent → Alloy migration, xray-knife update, teddysun/xray 26.6.1 upgrade.