### PR TITLE
chore: upgrade xray-knife v3 → v10

### DIFF
--- a/xray-config/Dockerfile
+++ b/xray-config/Dockerfile
@@ -21,10 +21,10 @@ RUN apk add --no-cache --virtual .build-deps wget unzip && \
         echo "Unsupported architecture: $ARCH" >&2; \
         exit 1; \
     fi && \
-    wget -L -O knife.zip "https://github.com/lilendian0x00/xray-knife/releases/download/v3.27.64/Xray-knife-linux-${arch_name}.zip" && \
+    wget -L -O knife.zip "https://github.com/lilendian0x00/xray-knife/releases/download/v10.0.0/Xray-knife-linux-${arch_name}.zip" && \
     unzip knife.zip && \
     mv ./xray-knife /usr/bin/ && \
-    rm knife.zip && \
+    rm -f knife.zip LICENSE README.md && \
     \
     # Install acme.sh
     curl https://get.acme.sh | sh && \

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -168,20 +168,18 @@ class XrayService:
             exec_command(
                 [
                     "xray-knife",
-                    "net",
                     "http",
                     "--thread",
-                    "1",
+                    "6",
+                    "-v",
                     "-d",
-                    "30000",
-                    "-r",
+                    "10000",
                     "-e",
-                    "-p",
-                    "-a",
-                    "1000",
                     "-f",
                     str(CONFIGS_CSV),
-                    "--type",
+                    "-o",
+                    str(VALID_CSV),
+                    "-x",
                     "csv",
                 ]
             )


### PR DESCRIPTION

- Bump xray-knife download to v10.0.0
- Fix post-unzip cleanup (v10 zip includes `LICENSE` and `README.md`)
- `net http` → `http` (top-level command in v10)
- Replace input `--type csv` with output flags `-o <path> -x csv`
- Threads 1 → 6, max delay 30s → 10s
- Drop unused speedtest flags (`-p`, `-a`) and redundant `-r`
- Add `-v` for per-config result logging