### PR TITLE
fix(show-configs): consistent config name display across vmess and vless

### DIFF
--- a/shared_lib/xray.py
+++ b/shared_lib/xray.py
@@ -29,6 +29,7 @@ def parse_config_link(link: str) -> Dict[str, Any]:
                 "id": data.get("id"),
                 "security": data.get("scy", "auto"),
                 "type": data.get("net", "tcp"),
+                "name": data.get("ps", ""),
             }
         except Exception as e:
             raise ValueError(f"Failed to decode vmess link: {e}")
@@ -43,6 +44,7 @@ def parse_config_link(link: str) -> Dict[str, Any]:
                 "id": parsed.username,
                 "security": query.get("security", ["none"])[0],
                 "type": query.get("type", ["tcp"])[0],
+                "name": parsed.fragment or "",
             }
         except Exception as e:
             raise ValueError(f"Failed to parse vless link: {e}")

--- a/show_configs.sh
+++ b/show_configs.sh
@@ -1,35 +1,31 @@
 #!/usr/bin/bash
 
-# Get raw metrics data
-raw_data=$(docker compose exec xray-config curl -s http://localhost:5000/metrics)
+raw_data=$(docker compose exec xray-config curl -s http://localhost:5000/metrics 2>/dev/null)
 
-# Print header
-echo 
+echo
 echo "CompassVPN Configuration Links"
 echo "=============================="
 echo
 
-# Filter out the HELP and TYPE lines, then process each vpn_config line
+if [ -z "$raw_data" ]; then
+    echo "No data available. The xray-config service may not be ready yet."
+    echo
+    echo "=============================="
+    echo
+    exit 0
+fi
+
 echo "$raw_data" | grep "vpn_config" | grep -v "HELP" | grep -v "TYPE" | while read -r line; do
-    # Extract the config name (from the end of the config_link, after the #)
-    config_name=$(echo "$line" | grep -o '#[^"]*' | sed 's/#//')
-    
-    # Extract the config link
-    config_link=$(echo "$line" | grep -o 'config_link="[^"]*' | sed 's/config_link="//g')
-    
-    # Extract latency value (number at the end of the line)
+    config_name=$(echo "$line" | grep -o 'config_name="[^"]*"' | sed 's/config_name="//;s/"//')
+    config_link=$(echo "$line" | grep -o 'config_link="[^"]*"' | sed 's/config_link="//;s/"$//')
     latency=$(echo "$line" | awk '{print $NF}')
-    
-    # Simple status based on latency
-    status="Working"
+
     if [ "$latency" = "-1" ]; then
-        status="Not Working"
+        echo "${config_name:-unknown} (FAIL: -1 ms)"
+    else
+        echo "${config_name:-unknown} (OK: ${latency} ms)"
     fi
-    
-    # Print formatted output
-    echo "$config_name"
-    echo "Status: $status (Latency: $latency ms)"
-    echo "$config_link"
+    echo "${config_link}"
     echo
 done
 

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -91,6 +91,7 @@ class XrayService:
                 config_info = parse_config_link(config_link)
                 labels = [
                     f'config_link="{config_link}"',
+                    f'config_name="{config_info["name"]}"',
                     f'machine_id="{get_machine_id()}"',
                     f'ip="{instance_ip}"',
                     f'country="{instance_country}"',


### PR DESCRIPTION


- **`shared_lib/xray.py`**: `parse_config_link()` now extracts the `ps` field (vmess) and URL fragment (vless) as a `name` key in the returned dict
- **`xray-config/run.py`**: `update_metrics()` exposes `config_name` as a Prometheus label alongside existing labels
- **`show_configs.sh`**: reads the config name from the `config_name` Prometheus label (instead of URL fragment, which vmess links don't have), and formats output as `name (OK: X ms)` / `name (FAIL: -1 ms)`

## Problem

`show_configs.sh` was extracting the config name from the `#fragment` of the config URL. vmess links are base64-encoded and have no fragment, so vmess entries always showed `unknown` as the name.