### PR TITLE
fix(nginx): stop crash-looping on non-CF deployments

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,8 @@
 FROM nginx:1.31.1-alpine-slim
 
-RUN apk add curl jq
+RUN apk add --no-cache curl jq gettext
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
+COPY ./tls_servers.conf.template /etc/nginx/tls_servers.conf.template
 
 COPY ./entrypoint.sh /docker-entrypoint.sh

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,65 +1,75 @@
 #!/bin/sh
+set -eu
 
 NGINX_CONF_PATH=/etc/nginx/nginx.conf
+TLS_TEMPLATE=/etc/nginx/tls_servers.conf.template
+TLS_CONF=/etc/nginx/conf.d/tls_servers.conf
+XRAY_CONFIG_BASE="http://xray-config:5000"
+MAX_RETRIES=60
 
-sed -i "s|\${NGINX_FAKE_WEBSITE}|$NGINX_FAKE_WEBSITE|g" "$NGINX_CONF_PATH"
-sed -i "s|\${NGINX_PATH}|$NGINX_PATH|g" "$NGINX_CONF_PATH"
+mkdir -p /etc/nginx/conf.d
 
-UPSTREAM_URL="http://xray-config:5000/subdomain"
+NGINX_LOG_LEVEL="warn"
+if [ "${DEBUG:-false}" = "true" ]; then
+    NGINX_LOG_LEVEL="debug"
+fi
 
-MAX_RETRIES=30
+# Wait for xray-config to fully initialize and capture nginx locations in one
+# request. /nginx-locations returns 503 while config.initialized is False.
+echo "Waiting for xray-config to initialize..."
 RETRY_COUNT=0
-DIRECT_SUBDOMAIN=""
-
-while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+LOCATIONS="{}"
+while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
     TMPFILE=$(mktemp)
-    HTTP_CODE=$(curl -s -o "$TMPFILE" -w "%{http_code}" "$UPSTREAM_URL")
-    BODY_TEXT=$(cat "$TMPFILE")
-    rm -f "$TMPFILE"
-
-    if [ "$HTTP_CODE" -eq 200 ] && [ -n "$BODY_TEXT" ]; then
-        DIRECT_SUBDOMAIN="$BODY_TEXT"
-        echo "xray-config is ready: $UPSTREAM_URL ($DIRECT_SUBDOMAIN)"
+    HTTP_CODE=$(curl -s -o "$TMPFILE" -w "%{http_code}" \
+        "$XRAY_CONFIG_BASE/nginx-locations" 2>/dev/null || printf "000")
+    if [ "$HTTP_CODE" -eq 200 ]; then
+        LOCATIONS=$(cat "$TMPFILE")
+        rm -f "$TMPFILE"
+        echo "xray-config is ready"
         break
     fi
-
-    echo "Waiting for xray-config subdomain... (HTTP status: $HTTP_CODE)"
+    rm -f "$TMPFILE"
+    echo "Waiting for xray-config... (HTTP $HTTP_CODE, attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)"
     sleep 2
     RETRY_COUNT=$((RETRY_COUNT + 1))
 done
 
-if [ -z "$DIRECT_SUBDOMAIN" ]; then
-    echo "Error: xray-config subdomain not available after $MAX_RETRIES retries"
+if [ "$RETRY_COUNT" -eq "$MAX_RETRIES" ]; then
+    echo "Error: xray-config not ready after $MAX_RETRIES retries"
     exit 1
 fi
 
-# Set Nginx log level based on DEBUG env
-NGINX_LOG_LEVEL="warn"
-if [ "$DEBUG" = "true" ]; then
-    NGINX_LOG_LEVEL="debug"
-fi
+# Render static placeholders in the main config.
+# The explicit variable list leaves nginx's own $variables untouched.
+NGINX_LOG_LEVEL="$NGINX_LOG_LEVEL" \
+    envsubst '${NGINX_FAKE_WEBSITE}${NGINX_PATH}${NGINX_LOG_LEVEL}' \
+    < "$NGINX_CONF_PATH" > /tmp/nginx.conf && mv /tmp/nginx.conf "$NGINX_CONF_PATH"
 
-# Robust replacement for the global error_log directive
-if grep -q "^error_log /var/log/compassvpn/nginx_error.log" "$NGINX_CONF_PATH"; then
-    sed -i "s|^error_log /var/log/compassvpn/nginx_error.log.*|error_log /var/log/compassvpn/nginx_error.log $NGINX_LOG_LEVEL;|" "$NGINX_CONF_PATH"
+# TLS server blocks require a Cloudflare subdomain and certificate.
+# When CF credentials are present the subdomain is always available at this
+# point because xray-config finished initializing above.
+if [ -n "${CF_API_TOKEN:-}" ] && [ -n "${CF_ZONE_ID:-}" ]; then
+    DIRECT_SUBDOMAIN=$(curl -sf "$XRAY_CONFIG_BASE/subdomain")
+    DIRECT_SUBDOMAIN="$DIRECT_SUBDOMAIN" \
+        envsubst '${NGINX_FAKE_WEBSITE}${NGINX_PATH}${DIRECT_SUBDOMAIN}' \
+        < "$TLS_TEMPLATE" > "$TLS_CONF"
+    echo "TLS config generated for $DIRECT_SUBDOMAIN"
 else
-    echo "Warning: error_log directive for nginx_error.log not found in $NGINX_CONF_PATH"
+    echo "Cloudflare not configured: TLS server blocks disabled"
+    : > "$TLS_CONF"
 fi
 
-sed -i "s|\${DIRECT_SUBDOMAIN}|$DIRECT_SUBDOMAIN|g" "$NGINX_CONF_PATH"
-
-# Fetch replica location blocks and write include files (empty = no replicas configured)
-LOCATIONS=$(curl -sf "http://xray-config:5000/nginx-locations" 2>/dev/null || echo "{}")
+# Write per-port replica location blocks.
 for port in 2053 8880 8443; do
     mkdir -p "/etc/nginx/locations.d/$port"
-    printf '%s\n' "$(echo "$LOCATIONS" | jq -r ".\"$port\" // empty")" \
+    printf '%s\n' "$(printf '%s' "$LOCATIONS" | jq -r ".\"$port\" // empty")" \
         > "/etc/nginx/locations.d/$port/replicas.conf"
 done
 
+# Watch for cert renewal flag and reload nginx when it changes.
 CERT_FLAG="/var/log/compassvpn/.cert_renewed"
 LAST_FLAG_TIME=""
-
-# Watch for cert renewal flag and reload nginx when it appears
 (
     while true; do
         if [ -f "$CERT_FLAG" ]; then

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,7 +2,7 @@ user nginx;
 worker_processes auto;
 worker_rlimit_nofile 65535;
 
-error_log /var/log/compassvpn/nginx_error.log warn;
+error_log /var/log/compassvpn/nginx_error.log ${NGINX_LOG_LEVEL};
 pid /var/run/nginx.pid;
 
 events {
@@ -54,7 +54,7 @@ http {
     server {
         listen 0.0.0.0:8001 proxy_protocol;
         http2 on;
-        
+
         set_real_ip_from 127.0.0.1;
         real_ip_header proxy_protocol;
 
@@ -64,78 +64,6 @@ http {
         }
 
         # Forwards all incoming requests from xray to an external website.
-        location / {
-            sub_filter $proxy_host $host;
-            sub_filter_once off;
-            set $website ${NGINX_FAKE_WEBSITE};
-            proxy_pass https://$website;
-
-            proxy_set_header Host $proxy_host;
-            proxy_http_version 1.1;
-            proxy_cache_bypass $http_upgrade;
-            proxy_ssl_server_name on;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Forwarded $proxy_add_forwarded;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
-        }
-    }
-
-    # Vless-HU-TLS Handling. (Both direct and CDN)
-    server {
-        listen 2053 ssl reuseport;
-        listen [::]:2053 ssl reuseport;
-        http2 on;
-        
-        ssl_certificate /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/fullchain.cer;
-        ssl_certificate_key /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/${DIRECT_SUBDOMAIN}.key;
-        ssl_protocols TLSv1.3;
-
-        # Block sensitive paths
-        if ($is_forbidden_path = 1) {
-            return 403;
-        }
-
-        # Forwards this path requests to xray (direct).
-        location = /${NGINX_PATH}/1 {
-            if ($http_upgrade != "websocket") {
-                return 404;
-            }
-            proxy_pass http://xray:8002;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $host;
-            proxy_redirect off;
-        }
-
-        # Forwards this path requests to xray (cdn).
-        location = /${NGINX_PATH}/cdn/1 {
-            if ($http_upgrade != "websocket") {
-                return 404;
-            }
-            proxy_pass http://xray:8022;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host $host;
-            proxy_redirect off;
-        }
-
-        include /etc/nginx/locations.d/2053/replicas.conf;
-
-        # Fallback all other requests to an external website.
         location / {
             sub_filter $proxy_host $host;
             sub_filter_once off;
@@ -224,74 +152,9 @@ http {
         }
     }
 
-    # Vless-XHTTP-QUIC Handling.
-    server {
-        # Vless-xhttp-quic-direct; Client will connect directly with alpn=h3,h2 (h2 for fallback when h3 is not available).
-        listen 8443 quic reuseport;
-        listen [::]:8443 quic reuseport;
-        # Vless-xhttp-quic-CDN; Client will connect to CF with alpn=h3,h2 (h2 for fallback when h3 is not available) and CF will connect to VM with h2,http1.1.
-        listen 8443 ssl reuseport;
-        listen [::]:8443 ssl reuseport;
-        http2 on;
-        
-        ssl_certificate /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/fullchain.cer;
-        ssl_certificate_key /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/${DIRECT_SUBDOMAIN}.key;
-        ssl_protocols TLSv1.3;
-        ssl_early_data on;
-        
-        add_header Alt-Svc 'h3=":8443"; ma=86400' always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-        add_header QUIC-Status $http3;
-        
-        # Block sensitive paths
-        if ($is_forbidden_path = 1) {
-            return 403;
-        }
-
-        # Forwards this path requests to xray (direct).
-        location /${NGINX_PATH}/1 {
-            grpc_pass grpc://xray:8003;
-            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            grpc_read_timeout 315;
-            grpc_send_timeout 5m;
-            client_body_timeout 5m;
-            client_max_body_size 0;
-        }
-
-        # Forwards this path requests to xray (cdn).
-        location /${NGINX_PATH}/cdn/1 {
-            grpc_pass grpc://xray:8033;
-            grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            grpc_read_timeout 315;
-            grpc_send_timeout 5m;
-            client_body_timeout 5m;
-            client_max_body_size 0;
-        }
-        
-        include /etc/nginx/locations.d/8443/replicas.conf;
-
-        # Fallback all other requests to an external website.
-        location / {
-            sub_filter $proxy_host $host;
-            sub_filter_once off;
-            set $website ${NGINX_FAKE_WEBSITE};
-            proxy_pass https://$website;
-
-            proxy_set_header Host $proxy_host;
-            proxy_http_version 1.1;
-            proxy_cache_bypass $http_upgrade;
-            proxy_ssl_server_name on;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Forwarded $proxy_add_forwarded;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Forwarded-Port $server_port;
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
-        }
-    }
+    # TLS server blocks (ports 2053 and 8443) are rendered into this file by
+    # the entrypoint only when a Cloudflare subdomain and certificate are
+    # available. The file is always present (empty for non-CF deployments) so
+    # this include never causes a startup error.
+    include /etc/nginx/conf.d/tls_servers.conf;
 }

--- a/nginx/tls_servers.conf.template
+++ b/nginx/tls_servers.conf.template
@@ -1,0 +1,142 @@
+# Vless-HU-TLS Handling. (Both direct and CDN)
+server {
+    listen 2053 ssl reuseport;
+    listen [::]:2053 ssl reuseport;
+    http2 on;
+
+    ssl_certificate /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/fullchain.cer;
+    ssl_certificate_key /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/${DIRECT_SUBDOMAIN}.key;
+    ssl_protocols TLSv1.3;
+
+    # Block sensitive paths
+    if ($is_forbidden_path = 1) {
+        return 403;
+    }
+
+    # Forwards this path requests to xray (direct).
+    location = /${NGINX_PATH}/1 {
+        if ($http_upgrade != "websocket") {
+            return 404;
+        }
+        proxy_pass http://xray:8002;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+    # Forwards this path requests to xray (cdn).
+    location = /${NGINX_PATH}/cdn/1 {
+        if ($http_upgrade != "websocket") {
+            return 404;
+        }
+        proxy_pass http://xray:8022;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+    include /etc/nginx/locations.d/2053/replicas.conf;
+
+    # Fallback all other requests to an external website.
+    location / {
+        sub_filter $proxy_host $host;
+        sub_filter_once off;
+        set $website ${NGINX_FAKE_WEBSITE};
+        proxy_pass https://$website;
+
+        proxy_set_header Host $proxy_host;
+        proxy_http_version 1.1;
+        proxy_cache_bypass $http_upgrade;
+        proxy_ssl_server_name on;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Forwarded $proxy_add_forwarded;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}
+
+# Vless-XHTTP-QUIC Handling.
+server {
+    # Vless-xhttp-quic-direct; Client will connect directly with alpn=h3,h2 (h2 for fallback when h3 is not available).
+    listen 8443 quic reuseport;
+    listen [::]:8443 quic reuseport;
+    # Vless-xhttp-quic-CDN; Client will connect to CF with alpn=h3,h2 (h2 for fallback when h3 is not available) and CF will connect to VM with h2,http1.1.
+    listen 8443 ssl reuseport;
+    listen [::]:8443 ssl reuseport;
+    http2 on;
+
+    ssl_certificate /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/fullchain.cer;
+    ssl_certificate_key /root/.acme.sh/${DIRECT_SUBDOMAIN}_ecc/${DIRECT_SUBDOMAIN}.key;
+    ssl_protocols TLSv1.3;
+    ssl_early_data on;
+
+    add_header Alt-Svc 'h3=":8443"; ma=86400' always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header QUIC-Status $http3;
+
+    # Block sensitive paths
+    if ($is_forbidden_path = 1) {
+        return 403;
+    }
+
+    # Forwards this path requests to xray (direct).
+    location /${NGINX_PATH}/1 {
+        grpc_pass grpc://xray:8003;
+        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        grpc_read_timeout 315;
+        grpc_send_timeout 5m;
+        client_body_timeout 5m;
+        client_max_body_size 0;
+    }
+
+    # Forwards this path requests to xray (cdn).
+    location /${NGINX_PATH}/cdn/1 {
+        grpc_pass grpc://xray:8033;
+        grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        grpc_read_timeout 315;
+        grpc_send_timeout 5m;
+        client_body_timeout 5m;
+        client_max_body_size 0;
+    }
+
+    include /etc/nginx/locations.d/8443/replicas.conf;
+
+    # Fallback all other requests to an external website.
+    location / {
+        sub_filter $proxy_host $host;
+        sub_filter_once off;
+        set $website ${NGINX_FAKE_WEBSITE};
+        proxy_pass https://$website;
+
+        proxy_set_header Host $proxy_host;
+        proxy_http_version 1.1;
+        proxy_cache_bypass $http_upgrade;
+        proxy_ssl_server_name on;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Forwarded $proxy_add_forwarded;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}


### PR DESCRIPTION
nginx was crash-looping on any deployment without Cloudflare because the TLS server blocks (ports 2053, 8443) had `ssl_certificate` paths that referenced `${DIRECT_SUBDOMAIN}` , which is only ever set with CF credentials. nginx refused to start, restarted every ~60s forever.

**what changed**
- extracted the two TLS server blocks into `tls_servers.conf.template`
- entrypoint renders them via `envsubst` only when `CF_API_TOKEN` + `CF_ZONE_ID` are set; otherwise writes an empty include file
- replaced all `sed` placeholder substitutions with `envsubst` (explicit var list so nginx's own `$variables` are untouched)
- readiness probe switched from `/subdomain` to `/nginx-locations` , works for both CF and non-CF