### PR TITLE
fix(web-panel): correct NGINX_PATH validation logic

### DIFF
--- a/web_panel/app.py
+++ b/web_panel/app.py
@@ -1,4 +1,5 @@
 import os
+import re
 import signal
 import json
 from typing import Dict, List, Any
@@ -279,7 +280,7 @@ def index() -> Any:
             # Specific validation for NGINX_PATH
             if key == "NGINX_PATH":
                 value = value.strip("/")
-                if not value.isalnum() and "_" not in value and "-" not in value:
+                if not re.fullmatch(r'[a-zA-Z0-9_-]+', value):
                     errors.append(
                         "NGINX Path must be alphanumeric (dashes/underscores allowed)."
                     )


### PR DESCRIPTION
The previous guard used `and` between conditions, meaning a value containing an underscore or dash bypassed all character checks and could inject arbitrary content into nginx.conf via envsubst. Replace with re.fullmatch to whitelist only [a-zA-Z0-9_-].