### PR TITLE
fix(xray): reload TLS cert after renewal

### DIFF
--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -685,6 +685,29 @@ Endpoint = engage.cloudflareclient.com:2408
 
         self.initialized = True
 
+    def reload_certs(self) -> bool:
+        """Re-read renewed cert files from disk and patch xray_config TLS inbounds in-place."""
+        if not self.direct_subdomain:
+            return False
+        cert_path = ACME_SH_PATH / f"{self.direct_subdomain}_ecc" / "fullchain.cer"
+        key_path = ACME_SH_PATH / f"{self.direct_subdomain}_ecc" / f"{self.direct_subdomain}.key"
+        try:
+            with open(cert_path, "r") as f:
+                self.cert_public = f.read()
+            with open(key_path, "r") as f:
+                self.cert_private = f.read()
+        except Exception as e:
+            log.error("reload_certs: failed to read cert files", hypothesisId="CERT", error=str(e))
+            return False
+        for inbound in self.xray_config.get("inbounds", []):
+            tls = inbound.get("streamSettings", {}).get("tlsSettings", {})
+            for cert_entry in tls.get("certificates", []):
+                if "certificate" in cert_entry:
+                    cert_entry["certificate"] = [self.cert_public]
+                if "key" in cert_entry:
+                    cert_entry["key"] = [self.cert_private]
+        return True
+
     def get_config_links(self) -> List[str]:
         """Return formatted config links for active inbounds."""
         configs: List[str] = []

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -230,6 +230,17 @@ class XrayService:
                 )
                 if result.returncode == 0:
                     # Cert files on the shared acme volume are now updated.
+                    # Reload certs into config so the /config endpoint serves fresh PEMs.
+                    if config.reload_certs():
+                        log.info(
+                            "In-memory certs and xray_config updated after renewal",
+                            hypothesisId="CERT",
+                        )
+                    else:
+                        log.error(
+                            "reload_certs failed after renewal; xray will serve stale cert until restart",
+                            hypothesisId="CERT",
+                        )
                     # Write a flag file so that nginx can detect the renewal and reload.
                     try:
                         flag_path = "/var/log/compassvpn/.cert_renewed"

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -109,4 +109,20 @@ fi
 
 monit --version
 
+# Poll xray-config hourly; if the served config changes (e.g. renewed TLS cert),
+# write the new config.json and SIGHUP xray so it reloads without a full restart.
+config_watcher() {
+    while true; do
+        sleep 3600
+        new=$(curl -sf "$XRAY_CONFIG_URL") || continue
+        if [ "$new" != "$(cat /etc/xray/config.json)" ]; then
+            printf '%s' "$new" > /etc/xray/config.json
+            if [ -f /run/xray.pid ]; then
+                kill -HUP "$(cat /run/xray.pid)" && echo "xray config updated and reloaded"
+            fi
+        fi
+    done
+}
+config_watcher &
+
 monit -I


### PR DESCRIPTION
after `acme.sh --renew` the cert files on disk were updated but `xray_config` still had the old PEMs baked in, so xray kept serving the expired cert until container restart.

- `reload_certs()` re-reads disk and patches the TLS inbounds in `xray_config` in-place
- `cert_management_job` calls it right after a successful renewal
- `entrypoint.sh` watcher polls `/config` hourly and SIGHUPs xray if it changed