### PR TITLE
fix(compose): remove unused docker.sock mount from node-exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,6 @@ services:
       - "/proc:/host/proc:ro"
       - "/sys:/host/sys:ro"
       - "/:/rootfs:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock"
     environment:
       - TZ=UTC
     command:


### PR DESCRIPTION
the socket was mounted but no enabled collector uses it. grants full docker daemon access for no reason — standard container escape vector. just remove it.