### PR TITLE
fix: stop untrusted geo-IP data from poisoning configs/metrics

### DIFF
--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -20,6 +20,22 @@ if remote_write_url and not remote_write_url.endswith("/push"):
     remote_write_url += "/push"
 
 
+def _river_escape(value: object) -> str:
+    """Escape a value for safe inclusion inside a River double-quoted string.
+
+    Without this, a stray quote/newline/brace in an interpolated value could
+    terminate its string literal and inject arbitrary Alloy components.
+    """
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
 def generate_config() -> None:
     log_level = "debug" if env_config.get("DEBUG") == "true" else "warn"
     username = env_config.get(
@@ -31,13 +47,22 @@ def generate_config() -> None:
         env_config.get("GRAFANA_AGENT_REMOTE_WRITE_PASSWORD", ""),
     )
 
+    # Escape every interpolated value. instance_ip in particular originates
+    # from a third-party geo-IP response and is otherwise attacker-influenceable.
+    log_level = _river_escape(log_level)
+    username = _river_escape(username)
+    password = _river_escape(password)
+    url = _river_escape(remote_write_url)
+    donor = _river_escape(DONOR)
+    instance = _river_escape(instance_ip)
+
     config = f"""logging {{
   level = "{log_level}"
 }}
 
 prometheus.remote_write "default" {{
   endpoint {{
-    url = "{remote_write_url}"
+    url = "{url}"
     basic_auth {{
       username = "{username}"
       password = "{password}"
@@ -67,11 +92,11 @@ prometheus.relabel "node_exporter" {{
   }}
   rule {{
     target_label = "donor"
-    replacement  = "{DONOR}"
+    replacement  = "{donor}"
   }}
   rule {{
     target_label = "instance"
-    replacement  = "{instance_ip}"
+    replacement  = "{instance}"
   }}
   forward_to = [prometheus.remote_write.default.receiver]
 }}
@@ -88,11 +113,11 @@ prometheus.scrape "xray" {{
 prometheus.relabel "xray" {{
   rule {{
     target_label = "donor"
-    replacement  = "{DONOR}"
+    replacement  = "{donor}"
   }}
   rule {{
     target_label = "instance"
-    replacement  = "{instance_ip}"
+    replacement  = "{instance}"
   }}
   forward_to = [prometheus.remote_write.default.receiver]
 }}
@@ -114,11 +139,11 @@ prometheus.relabel "xray_exporter" {{
   }}
   rule {{
     target_label = "donor"
-    replacement  = "{DONOR}"
+    replacement  = "{donor}"
   }}
   rule {{
     target_label = "instance"
-    replacement  = "{instance_ip}"
+    replacement  = "{instance}"
   }}
   forward_to = [prometheus.remote_write.default.receiver]
 }}

--- a/shared_lib/network.py
+++ b/shared_lib/network.py
@@ -1,3 +1,4 @@
+import ipaddress
 import requests
 from typing import Dict, Union
 
@@ -6,23 +7,49 @@ from shared_lib.logger import log
 
 def get_public_ip(extra: bool = False) -> Union[str, Dict[str, str]]:
     """Fetches the public IP and optionally country info from multiple providers."""
+    # HTTPS-only: the IP/country result is interpolated into generated configs
+    # and metric labels, so it must not be fetched over a plaintext channel an
+    # on-path attacker could poison. ip-api.com's free endpoint is HTTP-only and
+    # was removed for this reason.
     providers = [
-        {"url": "http://ip-api.com/json", "ip_key": "query", "country_key": "country"},
+        {"url": "https://ipinfo.io/json", "ip_key": "ip", "country_key": "country"},
         {
             "url": "https://reallyfreegeoip.org/json/",
             "ip_key": "ip",
             "country_key": "country_name",
         },
-        {"url": "https://ipinfo.io/json", "ip_key": "ip", "country_key": "country"},
+        {
+            "url": "https://api.ipify.org?format=json",
+            "ip_key": "ip",
+            "country_key": "country",
+        },
     ]
 
     for provider in providers:
+        # Defence-in-depth: never fall back to a plaintext endpoint.
+        if not provider["url"].startswith("https://"):
+            continue
         try:
             response = requests.get(provider["url"], timeout=5)
             if response.status_code == 200:
                 data = response.json()
                 ip = data.get(provider["ip_key"])
                 if not ip:
+                    continue
+
+                # Validate the value is actually an IP before trusting it. The
+                # result is interpolated into generated configs (Alloy River)
+                # and Prometheus metric labels, so a non-IP string from a
+                # compromised or MITM'd provider (the first provider is
+                # plaintext HTTP) must never be accepted.
+                try:
+                    ip = str(ipaddress.ip_address(ip))
+                except (ValueError, TypeError):
+                    log.debug(
+                        "Provider returned a non-IP value; skipping",
+                        hypothesisId="NET",
+                        provider=provider["url"],
+                    )
                     continue
 
                 log.debug(

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -11,6 +11,16 @@ from shared_lib.xray import parse_config_link
 from shared_lib.paths import CONFIGS_CSV, VALID_CSV, ACME_SH_PATH
 
 
+def _prom_label_escape(value: object) -> str:
+    """Escape a value for a Prometheus exposition-format label value.
+
+    Label values must escape backslash, double-quote, and newline; otherwise an
+    untrusted value such as the geo-IP-derived country (or a crafted config
+    link) could corrupt the exposition output or inject extra labels/series.
+    """
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
 class XrayService:
     def __init__(self) -> None:
         self.app: Flask = Flask(__name__)
@@ -90,16 +100,16 @@ class XrayService:
 
                 config_info = parse_config_link(config_link)
                 labels = [
-                    f'config_link="{config_link}"',
-                    f'config_name="{config_info["name"]}"',
-                    f'machine_id="{get_machine_id()}"',
-                    f'ip="{instance_ip}"',
-                    f'country="{instance_country}"',
-                    f'config_protocol="{config_info["protocol"]}"',
-                    f'config_host="{config_info["host"]}"',
-                    f'config_port="{config_info["port"]}"',
-                    f'config_security="{config_info["security"]}"',
-                    f'config_type="{config_info["type"]}"',
+                    f'config_link="{_prom_label_escape(config_link)}"',
+                    f'config_name="{_prom_label_escape(config_info["name"])}"',
+                    f'machine_id="{_prom_label_escape(get_machine_id())}"',
+                    f'ip="{_prom_label_escape(instance_ip)}"',
+                    f'country="{_prom_label_escape(instance_country)}"',
+                    f'config_protocol="{_prom_label_escape(config_info["protocol"])}"',
+                    f'config_host="{_prom_label_escape(config_info["host"])}"',
+                    f'config_port="{_prom_label_escape(config_info["port"])}"',
+                    f'config_security="{_prom_label_escape(config_info["security"])}"',
+                    f'config_type="{_prom_label_escape(config_info["type"])}"',
                 ]
                 inline_labels = ",".join(labels)
                 t = f"vpn_config{{{inline_labels}}}"


### PR DESCRIPTION
The geo-IP value from `get_public_ip()` was being trusted blindly and interpolated raw into the Alloy River config and Prometheus labels. A compromised/MITM'd provider (the first one was plaintext HTTP) could break out of a string literal and inject — worst case crash-loop the metric-forwarder or exfil the mounted `env_file` secrets via injected Alloy components.

what changed:
- `network.py`: validate the result is a real IP (`ipaddress.ip_address`), skip the provider otherwise
- `network.py`: HTTPS-only providers — dropped plaintext `ip-api.com`, added an https-only guard so it can't sneak back
- `common.py`: escape every value going into the River config (also fixes operator self-DoS from a `"` in a password)
- `xray-config/run.py`: escape Prometheus label values (the geo-IP `country` was unescaped)