### PR TITLE
harden: drop container capabilities + lock down node-exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,25 @@
-x-logging-and-limits: &high-perf
+# CompassVPN stack. Six containers working together:
+#   xray-config  - builds the Xray config and gets/renews TLS certs (internal only)
+#   xray         - the actual proxy; handles all the public VPN traffic
+#   nginx        - public TLS front + a decoy site for anything that isn't real traffic
+#   xray-exporter / metric-forwarder / node-exporter - the metrics pipeline
+#
+# The anchors below keep the repeated logging / tuning / hardening bits in one
+# place so we set them once and reuse them.
+
+# Tuning for the busy, public-facing services (xray, nginx): raise the open-file
+# limit, tune the TCP stack a bit, and keep a little more log history.
+x-public-tuned: &public-tuned
   ulimits:
     nofile:
       soft: 65535
       hard: 65535
+  # These sysctls are per-network-namespace, so they apply only inside the
+  # container - intentionally separate from the host values in prepare_vm.sh
+  # (don't delete them thinking they're duplicates).
   sysctls:
     - net.core.somaxconn=8192
-    - net.ipv4.tcp_max_syn_backlog=8192
+    - net.ipv4.tcp_max_syn_backlog=10240   # match the host value in prepare_vm.sh
     - net.ipv4.tcp_fin_timeout=25
   logging:
     driver: "json-file"
@@ -13,45 +27,64 @@ x-logging-and-limits: &high-perf
       max-size: "10m"
       max-file: "3"
 
-x-logging-minimal: &minimal-perf
+# The quiet helper services don't need that tuning - just keep their logs small.
+# (Logging only, no perf settings - hence the name.)
+x-log-small: &log-small
   logging:
     driver: "json-file"
     options:
       max-size: "5m"
       max-file: "1"
 
+# Baseline hardening shared by every service: forbid a process from gaining new
+# privileges (e.g. via a setuid binary). Capabilities are dropped per-service.
+x-hardening: &hardening
+  security_opt:
+    - "no-new-privileges:true"
+
 services:
 
+  # Brain of the stack: generates the Xray config, fetches/renews TLS certs via
+  # acme.sh + the Cloudflare API, and runs the config self-tests. Only talks to
+  # the other containers over the internal network - no published ports.
   xray-config:
     build:
       context: ./xray-config
       dockerfile: Dockerfile
     restart: always
-    <<: *minimal-perf
+    <<: [*log-small, *hardening]
+    cap_drop:
+      - ALL          # key crypto + outbound HTTPS + Flask on :5000; no caps needed
     env_file:
       - env_file
     environment:
       - TZ=UTC
       - PYTHONPATH=/
     volumes:
-      - "/etc/machine-id:/host/etc/machine-id"
-      - "acme:/root/.acme.sh/"
+      - "/etc/machine-id:/host/etc/machine-id"   # stable host id, used as a metric label
+      - "acme:/root/.acme.sh/"                    # cert store - this one writes it, xray/nginx read it
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/root/env_file:ro"
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
 
+  # The actual proxy - this is what clients connect to and where all the VPN
+  # traffic flows. In "warp" mode it also brings up a WireGuard tunnel for egress.
   xray:
     build:
       context: ./xray
       dockerfile: Dockerfile
-    <<: *high-perf
+    <<: [*public-tuned, *hardening]
     volumes:
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/env_file:ro"
-      - "acme:/root/.acme.sh/:ro"
+      - "acme:/root/.acme.sh/:ro"               # read-only: only xray-config renews certs
+    cap_drop:
+      - ALL
     cap_add:
-      - NET_ADMIN
+      - NET_ADMIN          # wg-quick creates the WireGuard interface (warp mode)
+      - NET_RAW            # busybox ping liveness check in wg_monit
+      - NET_BIND_SERVICE   # bind :443 (harmless now; needed if xray ever runs non-root)
     restart: always
     env_file:
       - env_file
@@ -59,18 +92,29 @@ services:
       - TZ=UTC
       - PYTHONPATH=/
     depends_on:
-      - xray-config
-    ports:
+      - xray-config        # needs the generated config before it can start
+    ports:                 # public entry points (both TCP and UDP)
       - "8080:8080/tcp"
       - "8080:8080/udp"
       - "443:443/tcp"
       - "443:443/udp"
 
+  # Public TLS front + camouflage. Real proxy paths get forwarded to xray;
+  # everything else falls through to a decoy website. Builds its config from
+  # what xray-config serves at startup.
   nginx:
     build:
       context: ./nginx
       dockerfile: Dockerfile
-    <<: *high-perf
+    <<: [*public-tuned, *hardening]
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID         # master spawns workers as the 'nginx' user
+      - SETGID
+      - CHOWN          # chown worker cache/temp dirs
+      - DAC_OVERRIDE   # master opens logs/pid/cache before dropping privileges
+      - KILL           # 'nginx -s reload' on cert renewal
     volumes:
       - "acme:/root/.acme.sh/"
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
@@ -79,7 +123,7 @@ services:
     restart: always
     env_file:
       - env_file
-    ports:
+    ports:                 # public entry points (both TCP and UDP)
       - "8880:8880/tcp"
       - "8880:8880/udp"
       - "2053:2053/tcp"
@@ -92,12 +136,15 @@ services:
     depends_on:
       - xray
 
+  # Reads Xray's access log and exposes it as Prometheus metrics on :9550.
   xray-exporter:
     build:
       context: ./xray-exporter
       dockerfile: Dockerfile
     restart: always
-    <<: *minimal-perf
+    <<: [*log-small, *hardening]
+    cap_drop:
+      - ALL          # outbound scrape + read-only log + :9550; no caps needed
     depends_on:
       - xray
     volumes:
@@ -107,19 +154,21 @@ services:
       - LOG_LEVEL=info
       - PYTHONPATH=/
 
+  # Runs Grafana Alloy: scrapes the local metrics (node-exporter, xray-config,
+  # xray-exporter) and ships them off to the remote Grafana endpoint.
   metric-forwarder:
     build:
       context: ./metric-forwarder
       dockerfile: Dockerfile
     restart: always
-    <<: *minimal-perf
+    <<: [*log-small, *hardening]
+    cap_drop:
+      - ALL          # pure outbound Alloy forwarder; no caps needed
     env_file:
       - env_file
     environment:
       - TZ=UTC
       - PYTHONPATH=/
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     volumes:
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/env_file:ro"
@@ -127,11 +176,18 @@ services:
       - xray-config
       - node-exporter
 
+  # Standard host metrics (CPU, memory, disk, network). Reads it all from the
+  # mounted host /proc + /sys, so it runs on the normal compose network like the
+  # others and is scraped internally as node-exporter:9100 - no host networking,
+  # no published port, nothing opened on the host firewall.
   node-exporter:
     image: prom/node-exporter:v1.11.1
     restart: always
-    network_mode: host
-    <<: *minimal-perf
+    <<: [*log-small, *hardening]
+    cap_drop:
+      - ALL          # enabled collectors are pure procfs/sysfs readers
+    read_only: true  # writes nothing; all mounts are read-only
+    user: "65534:65534"   # 'nobody' - this image already runs as nobody by default
     volumes:
       - "/proc:/host/proc:ro"
       - "/sys:/host/sys:ro"
@@ -142,6 +198,7 @@ services:
       - "--log.level=warn"
       - "--path.procfs=/host/proc"
       - "--path.sysfs=/host/sys"
+      # only collect what we actually graph - everything else stays off
       - '--collector.disable-defaults'
       - '--collector.uname'
       - '--collector.cpu'
@@ -151,7 +208,8 @@ services:
       - '--collector.time'
       - '--collector.stat'
       - '--collector.pressure'
-      - "--web.listen-address=172.17.0.1:9100" # only allow access from host.docker.internal interface
+      - "--web.listen-address=:9100" # internal only; reached by metric-forwarder over the compose network
 
+# Shared cert store: xray-config writes here (acme.sh), xray and nginx read from it.
 volumes:
   acme:

--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -72,7 +72,7 @@ prometheus.remote_write "default" {{
 
 prometheus.scrape "node_exporter" {{
   targets = [{{
-    __address__ = "host.docker.internal:9100",
+    __address__ = "node-exporter:9100",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/metrics"

--- a/prepare_vm.sh
+++ b/prepare_vm.sh
@@ -2,7 +2,7 @@
 
 # Configuration variables
 DNS_SERVERS=("1.1.1.2" "127.0.0.53")
-REQUIRED_PORTS=("80" "8080" "443" "2053" "8443" "9100")
+REQUIRED_PORTS=("80" "8080" "443" "2053" "8443")
 SYSCTL_CONF_PATH="/etc/sysctl.d/99-compassvpn.conf"
 
 # Paths


### PR DESCRIPTION
Container hardening pass + node-exporter lockdown, plus some compose tidy-up. All in one PR since the compose changes overlap.

## hardening 
Every service ran as root with the full default capability set. Now:
- `cap_drop: [ALL]` on all six, re-adding only what each genuinely needs:
  - **xray**: NET_ADMIN (wg-quick), NET_RAW (monit ping), NET_BIND_SERVICE
  - **nginx**: SETUID, SETGID, CHOWN, DAC_OVERRIDE, KILL
  - the other four need none
- `no-new-privileges` on all six
- node-exporter also runs `read_only` + non-root (65534)

## node-exporter / firewall
- dropped `network_mode: host` — it reads host stats from the mounted `/proc` + `/sys`, doesn't need the host netns
- now a normal bridge service, scraped as `node-exporter:9100` (common.py)
- removed `9100` from the host firewall (prepare_vm.sh) — it was opened on all interfaces for a port with no public listener
- removed the now-unused `host.docker.internal` extra_hosts on metric-forwarder

## tidy-up
- honest anchor names (`&minimal-perf` had zero perf in it -> `&log-small`; `&high-perf` -> `&public-tuned`)
- bumped container `tcp_max_syn_backlog` 8192 -> 10240 to match the host value
- comments throughout explaining what each service does and the non-obvious bits

