### PR TITLE
fix: write xray stdout to the persisted, rotated log path

### DIFF
--- a/xray/start_xray.sh
+++ b/xray/start_xray.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-/usr/bin/xray -c /etc/xray/config.json > /var/log/xray.log 2>&1 &
+/usr/bin/xray -c /etc/xray/config.json > /var/log/compassvpn/xray.log 2>&1 &
 
 echo $! > /run/xray.pid
 


### PR DESCRIPTION
**M16.** `start_xray.sh` sent xray's stdout/stderr to `/var/log/xray.log` inside the container — ephemeral (gone on restart) and never rotated.

Point it at `/var/log/compassvpn/xray.log`, which is on the mounted volume (persisted, visible from the host) and already covered by logrotate. The host setup even pre-creates that file, so it was just sitting empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)