### PR TITLE
fix: stop monit watchdog loops in the xray container

### DIFF
--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -60,11 +60,15 @@ if [ "$XRAY_OUTBOUND" = "warp" ]; then
   # Bring up wg interfaces
   for iface in $(echo "$WG_CONFIGS" | jq -r 'keys[]'); do
       echo "Bringing up $iface..."
-      /usr/bin/wg-quick up "$iface" || echo "Warning: Failed to bring up $iface"
-
-      MONIT_CONF_PATH="/etc/monit.d/$iface"
-      cp /wg_monit "$MONIT_CONF_PATH"
-      sed -i "s|\${INTERFACE}|$iface|g" "$MONIT_CONF_PATH"
+      # Only install the monit watchdog if the interface actually came up -
+      # otherwise monit loops forever trying to restart a dead interface.
+      if /usr/bin/wg-quick up "$iface"; then
+          MONIT_CONF_PATH="/etc/monit.d/$iface"
+          cp /wg_monit "$MONIT_CONF_PATH"
+          sed -i "s|\${INTERFACE}|$iface|g" "$MONIT_CONF_PATH"
+      else
+          echo "Warning: Failed to bring up $iface; skipping its monit watchdog"
+      fi
   done
 fi
 

--- a/xray/wg_monit
+++ b/xray/wg_monit
@@ -1,4 +1,5 @@
 check program ${INTERFACE} with path "/bin/ping -c 3 -I ${INTERFACE} 1.1.1.1"
   if status != 0 then restart
+  if 5 restarts within 5 cycles then unmonitor
   start program = "/usr/bin/wg-quick up ${INTERFACE}"
   stop program = "/usr/bin/wg-quick down ${INTERFACE}"

--- a/xray/xray_monit
+++ b/xray/xray_monit
@@ -1,3 +1,4 @@
 check process xray with pidfile "/run/xray.pid"
   start program = "/start_xray.sh"
   stop program = "/stop_xray.sh"
+  if 5 restarts within 5 cycles then unmonitor


### PR DESCRIPTION
Hardens the xray container's monit watchdogs.

**M17 — failed WG interface still got a watchdog → restart loop.** The entrypoint swallowed a `wg-quick up` failure and installed the monit watchdog anyway, so a dead interface got pinged + `wg-quick up`'d forever. Now the watchdog is only installed if the interface actually came up; a failure is logged and skipped.

**M17 + M18 — restart caps.** Added `if 5 restarts within 5 cycles then unmonitor` to both `wg_monit` and `xray_monit`, so a permanently-failing WG interface or a hard crash-looping xray gives up and alerts instead of churning endlessly.

Scope note on **M18**: this caps crash-loops, it does **not** add true hang-detection (process alive but not serving). A real liveness probe needs a port that's reliably bound, which is config-dependent (`XRAY_INBOUNDS`) — deferred rather than hard-coding a port that could itself cause false restarts.

Touches monitrc parsing, so the test deploy should confirm monit starts cleanly (`docker compose logs xray | grep -i monit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)