### PR TITLE
fix: give node-exporter --path.rootfs so disk metrics are the host's

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,7 @@ services:
       - "--log.level=warn"
       - "--path.procfs=/host/proc"
       - "--path.sysfs=/host/sys"
+      - "--path.rootfs=/rootfs" # statfs the host filesystems via the mounted root, not the container's
       # only collect what we actually graph - everything else stays off
       - '--collector.disable-defaults'
       - '--collector.uname'


### PR DESCRIPTION
**M20.** node-exporter mounts the host root at `/rootfs` and runs the filesystem collector, but `--path.rootfs` was missing. So it read the host mount list (via `/host/proc`) yet `statfs`'d each mountpoint at its literal path *inside the container* (default `--path.rootfs=/`) — meaning `node_filesystem_*{mountpoint="/"}` reported the container's overlay fs, not the host disk, and the `/rootfs` mount was effectively unused. Those series are kept by the relabel rules and graphed, so the disk panels were silently wrong.

Fix: add `--path.rootfs=/rootfs`.

Sanity check after deploy: `node_filesystem_avail_bytes{mountpoint="/"}` should jump from the container's few GB to the host disk's real size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)