### PR TITLE
fix: retry public IP at startup, fall back to node identifier

### DIFF
--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -1,14 +1,47 @@
+from time import sleep
+
 from shared_lib.network import get_public_ip
-from shared_lib.config import load_env
+from shared_lib.config import load_env, get_identifier
+from shared_lib.logger import log
 
 env_config = load_env()
 
-instance_location_info = get_public_ip(extra=True)
-instance_ip = (
-    instance_location_info.get("ip", "Unknown")
-    if isinstance(instance_location_info, dict)
-    else "Unknown"
-)
+# Resolve this node's public IP at startup. Retry a few times so a transient
+# network blip doesn't permanently freeze the label, then fall back to the
+# node's unique identifier - never a colliding "Unknown".
+_IP_RETRIES = 5
+_IP_RETRY_DELAY = 45  # seconds between attempts
+
+
+def _resolve_instance_ip() -> str:
+    for attempt in range(1, _IP_RETRIES + 1):
+        info = get_public_ip(extra=True)
+        ip = info.get("ip") if isinstance(info, dict) else None
+        if ip and ip != "Unknown":
+            return ip
+        log.warning(
+            "Public IP lookup failed; retrying",
+            hypothesisId="NET",
+            attempt=attempt,
+            of=_IP_RETRIES,
+        )
+        if attempt < _IP_RETRIES:
+            sleep(_IP_RETRY_DELAY)
+    # Persistent failure: use the node's unique identifier so metrics stay
+    # distinguishable instead of all colliding on "Unknown".
+    try:
+        fallback = get_identifier()
+    except Exception:
+        fallback = "unknown"
+    log.error(
+        "Public IP unresolved after retries; labeling metrics by identifier",
+        hypothesisId="NET",
+        instance=fallback,
+    )
+    return fallback
+
+
+instance_ip = _resolve_instance_ip()
 
 DONOR = env_config.get("DONOR", "compass")
 


### PR DESCRIPTION
**M22.** The forwarder resolved its public IP once at import. A transient lookup failure froze `instance_ip` to `"Unknown"` for the whole process (no self-heal), and every node that hit it collided on `instance="Unknown"` in the remote store — dashboards merge them, remote_write gets duplicate/out-of-order samples.

Now it retries 5× (~45s apart, ~3 min max) before giving up, and on persistent failure labels by the node's **unique identifier** instead of `"Unknown"` — so metrics stay distinguishable either way. The retry runs at startup so a brief boot/network blip resolves to the real IP.

Note: the same `ip` label in `xray-config`'s `update_metrics` has the same freeze-on-"Unknown" behavior — left out of scope here; can do it separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)