### PR TITLE
fix: don't mask remote deploy failures (exit $? expanded locally)

### DIFF
--- a/.github/scripts/deploy_logic.sh
+++ b/.github/scripts/deploy_logic.sh
@@ -101,8 +101,10 @@ ref_arg_quoted=$(printf %q "$GITHUB_REF_NAME")
 debug_flag_quoted=$(printf %q "$DEBUG_LOGS")
 
 # --- Execute the remote script ---
-# '; exit $?' ensures the remote shell exits with the script's status
-remote_script_execution_command="bash -s -- $repo_arg_quoted $ref_arg_quoted $debug_flag_quoted; exit $?"
+# '; exit \$?' - escaped so $? is evaluated on the REMOTE shell (the bootstrap's
+# real status). Unescaped, it would expand locally on the runner (always 0) and
+# mask every remote failure.
+remote_script_execution_command="bash -s -- $repo_arg_quoted $ref_arg_quoted $debug_flag_quoted; exit \$?"
 
 echo "Executing remote script ($LOCAL_SCRIPT_PATH) via stdin pipe..."
 


### PR DESCRIPTION
**M23.** The remote deploy command was built as `"...; exit $?"` in a double-quoted string **on the runner**, so `$?` expanded locally (to the previous local command's status — always `0`). The server therefore ran `…; exit 0` unconditionally, SSH returned 0, and every bootstrap failure (prepare_vm, `docker compose up`, etc.) showed up as a **successful** deploy.

Fix: escape it (`exit \$?`) so `$?` is evaluated on the **remote** shell — SSH then returns the bootstrap's real status and the `if/else` actually detects failures.

(Audit cited lines 133/139; the file's since been refactored — same bug at 104-105.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)