### PR TITLE
fix: always open files with encoding=utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ env_file
 .idea
 .ruff_cache
 .github
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -181,5 +181,5 @@ prometheus.relabel "xray_exporter" {{
   forward_to = [prometheus.remote_write.default.receiver]
 }}
 """
-    with open("config.alloy", "w") as f:
+    with open("config.alloy", "w", encoding="utf-8") as f:
         f.write(config)

--- a/shared_lib/logger.py
+++ b/shared_lib/logger.py
@@ -14,7 +14,7 @@ def _is_debug_enabled():
     # 2. Check env_file manually
     if os.path.exists(str(ENV_FILE)):
         try:
-            with open(str(ENV_FILE), "r") as f:
+            with open(str(ENV_FILE), "r", encoding="utf-8") as f:
                 for line in f:
                     # Robust check for DEBUG=true (handles spaces, optional quotes, etc.)
                     line = line.strip()

--- a/shared_lib/system.py
+++ b/shared_lib/system.py
@@ -10,7 +10,7 @@ def get_machine_id() -> str:
     paths = ["/host/etc/machine-id", "/etc/machine-id"]
     for path in paths:
         if os.path.exists(path):
-            with open(path, "r") as f:
+            with open(path, "r", encoding="utf-8") as f:
                 machine_id = f.read().strip()
                 log.debug(
                     "Machine ID retrieved",
@@ -69,7 +69,7 @@ def csv_to_dict(filename: str) -> Dict[str, List[str]]:
     data = {}
     if os.path.exists(filename):
         try:
-            with open(filename, "r") as f:
+            with open(filename, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if not line:

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -400,7 +400,7 @@ class XrayConfig:
                 return string.Template(data).safe_substitute(mapping)
             return data
 
-        with open(INBOUNDS_JSON) as f:
+        with open(INBOUNDS_JSON, encoding="utf-8") as f:
             raw_inbounds = json.load(f)
             all_inbounds = substitute_vars(
                 raw_inbounds,

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -170,7 +170,7 @@ class XrayService:
                     break
                 continue
 
-            with open(CONFIGS_CSV, "w") as configs_csv:
+            with open(CONFIGS_CSV, "w", encoding="utf-8") as configs_csv:
                 configs_csv.write("\n".join(valid_links))
 
             exec_command(["cat", str(CONFIGS_CSV)])
@@ -254,7 +254,7 @@ class XrayService:
                     # Write a flag file so that nginx can detect the renewal and reload.
                     try:
                         flag_path = "/var/log/compassvpn/.cert_renewed"
-                        with open(flag_path, "w") as f:
+                        with open(flag_path, "w", encoding="utf-8") as f:
                             import time as _time
                             f.write(str(_time.time()))
                         log.info(


### PR DESCRIPTION
`csv_to_dict` (and the other file reads) open without an explicit encoding, so they fall back to the locale default. On a non-UTF-8 locale a single non-ASCII byte — say a config remark with a flag emoji coming back from xray-knife's CSV — raises `UnicodeDecodeError`. In `csv_to_dict` the broad `except` quietly eats it and returns whatever rows it managed before the bad line, so you silently get a partial config set.

Doesn't bite today (the Alpine/musl images already report UTF-8), but it's relying on that quirk — swap to a glibc base and it'd start dropping data. This just makes every `open()` explicit, same as `config.py` already does. Also gitignored `__pycache__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)