### PR TITLE
make DEBUG one consistent flag across the stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,7 @@ services:
       - /var/log/compassvpn:/var/log/compassvpn:ro
       - "./shared_lib:/shared_lib:ro"
     environment:
-      - LOG_LEVEL=info
+      - LOG_LEVEL=warn   # WARN baseline like the rest of the stack (DEBUG-independent)
       - PYTHONPATH=/
 
   # Runs Grafana Alloy: scrapes the local metrics (node-exporter, xray-config,

--- a/env_file.example
+++ b/env_file.example
@@ -28,4 +28,6 @@ NGINX_FAKE_WEBSITE=www.divar.ir
 
 CUSTOM_DNS=controld
 
+# true = verbose logging across all containers, plus xray DNS-query logging and
+# a debug.log file. Use true/false.
 DEBUG=false

--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -2,7 +2,7 @@ from time import sleep
 
 from shared_lib.network import get_public_ip
 from shared_lib.config import load_env, get_identifier
-from shared_lib.logger import log
+from shared_lib.logger import log, is_debug
 
 env_config = load_env()
 
@@ -70,7 +70,7 @@ def _river_escape(value: object) -> str:
 
 
 def generate_config() -> None:
-    log_level = "debug" if env_config.get("DEBUG") == "true" else "warn"
+    log_level = "debug" if is_debug() else "warn"
     username = env_config.get(
         "ALLOY_REMOTE_WRITE_USER",
         env_config.get("GRAFANA_AGENT_REMOTE_WRITE_USER", ""),

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -9,8 +9,12 @@ MAX_RETRIES=60
 
 mkdir -p /etc/nginx/conf.d
 
+# Normalize DEBUG (accept True/TRUE/"true") to match the Python services.
+DEBUG=$(printf '%s' "${DEBUG:-false}" | tr -d "\"'" | tr '[:upper:]' '[:lower:]')
+
 NGINX_LOG_LEVEL="warn"
-if [ "${DEBUG:-false}" = "true" ]; then
+if [ "$DEBUG" = "true" ]; then
+    echo "Debug mode enabled"
     NGINX_LOG_LEVEL="debug"
 fi
 

--- a/shared_lib/logger.py
+++ b/shared_lib/logger.py
@@ -55,7 +55,8 @@ except Exception:
     pass
 
 
-log_level = logging.DEBUG if is_debug() else logging.INFO
+# Quiet by default (warnings + errors only); DEBUG=true turns on full verbosity.
+log_level = logging.DEBUG if is_debug() else logging.WARNING
 
 # Configure standard logging for both file and stdout
 logging.basicConfig(

--- a/shared_lib/logger.py
+++ b/shared_lib/logger.py
@@ -5,8 +5,14 @@ from typing import List
 from shared_lib.paths import DEBUG_LOG, ENV_FILE
 
 
-def _is_debug_enabled():
-    """Check if debug is enabled in environment or env_file without circular imports."""
+def is_debug() -> bool:
+    """Single source of truth for the DEBUG flag.
+
+    Checked here, the lowest-level module, so every other module can share one
+    definition (env var first, then env_file) without circular imports. Accepts
+    True/TRUE and optionally-quoted values so a stray capital doesn't half-enable
+    debug across the stack.
+    """
     # 1. Check environment
     if os.environ.get("DEBUG", "").lower() == "true":
         return True
@@ -39,16 +45,17 @@ try:
     if log_dir and not os.path.exists(log_dir):
         os.makedirs(log_dir, exist_ok=True)
 
-    # We always attempt to add the file handler if we're in debug mode
-    # or if the file already exists.
-    if _is_debug_enabled() or os.path.isfile(str(DEBUG_LOG)):
+    # Write debug.log only while DEBUG is on. (Previously this also fired when
+    # the file merely existed, so the log kept growing after DEBUG was turned
+    # back off until someone deleted it.)
+    if is_debug():
         handlers.append(logging.FileHandler(str(DEBUG_LOG)))
 except Exception:
     # Fail gracefully if we can't write to the log directory (e.g. permission issues)
     pass
 
 
-log_level = logging.DEBUG if _is_debug_enabled() else logging.INFO
+log_level = logging.DEBUG if is_debug() else logging.INFO
 
 # Configure standard logging for both file and stdout
 logging.basicConfig(
@@ -70,3 +77,7 @@ structlog.configure(
 )
 
 log = structlog.get_logger()
+
+# One line at startup so the operator can confirm the flag actually took effect.
+if is_debug():
+    log.info("Debug logging enabled", hypothesisId="LOG")

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -13,7 +13,7 @@ from shared_lib.network import get_public_ip
 from shared_lib.xray import register_warp, generate_vmess_link
 from shared_lib.config import load_env, get_identifier
 from shared_lib.system import exec_command
-from shared_lib.logger import log
+from shared_lib.logger import log, is_debug
 from shared_lib.paths import (
     ACME_SH_PATH,
     INBOUNDS_JSON,
@@ -270,7 +270,7 @@ class XrayConfig:
             return
 
         self.env_config = load_env()
-        self.is_debug_enabled = self.env_config.get("DEBUG", "false").lower() == "true"
+        self.is_debug_enabled = is_debug()
         log.debug(
             "Loaded env_config", hypothesisId="CFG", keys=list(self.env_config.keys())
         )

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -2,6 +2,12 @@
 
 rm -f /run/*.pid
 
+# Normalize DEBUG (accept True/TRUE/"true") to match the Python services.
+DEBUG=$(printf '%s' "${DEBUG:-false}" | tr -d "\"'" | tr '[:upper:]' '[:lower:]')
+if [ "$DEBUG" = "true" ]; then
+    echo "Debug mode enabled"
+fi
+
 # Mock resolvconf to prevent wg-quick from breaking Docker DNS
 # This keeps the container's /etc/resolv.conf (Docker DNS) intact.
 cat <<EOF > /usr/sbin/resolvconf


### PR DESCRIPTION
`DEBUG` was read in 6 places with 3 different levels of strictness, so only the exact lowercase `DEBUG=true` worked everywhere — `DEBUG=True`/`TRUE`/`"true"` turned debug on in some containers and silently off in others (metric-forwarder, nginx, xray entrypoint). And the non-debug *baseline* was a mix of INFO and WARN across services.

This roots both in one place.

**Consistent flag**
- **single `is_debug()` helper** in `shared_lib/logger.py` (the lowest-level module, no circular imports), used by xray-config and metric-forwarder instead of their own ad-hoc `== "true"` checks.
- the **nginx and xray entrypoints normalize** `DEBUG` the same way (case-insensitive + quote-tolerant), so the whole stack agrees.

**Consistent levels** — `DEBUG=false` → **WARN everywhere** (warnings + errors only), `DEBUG=true` → DEBUG. Most services were already WARN; the two loud ones move down:
- our Python apps (xray-config, metric-forwarder): INFO → WARN
- xray-exporter: `LOG_LEVEL=info` → `warn`
- xray core, Alloy, nginx, node-exporter: already WARN, untouched

(The two prom exporters take a static level from compose and stay DEBUG-independent — pinned to WARN.)

**Also**
- **`debug.log` is written only while DEBUG is on.** It used to also write whenever the file merely existed, so it kept growing after `DEBUG=false` until someone deleted it.
- each service **logs one line at startup** (`Debug logging enabled` / `Debug mode enabled`) so you can confirm the flag took effect.
- **documented** what the flag toggles in `env_file.example`.

Note: at the WARN baseline the Python apps no longer emit their normal-operation heartbeat (e.g. `xray test done - success: true`) unless `DEBUG=true` — intended, for a quiet production default.
