### PR TITLE
xray-exporter: bump to v0.4.0 and make its log level follow DEBUG

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,8 @@ services:
     volumes:
       - /var/log/compassvpn:/var/log/compassvpn:ro
       - "./shared_lib:/shared_lib:ro"
+    env_file:
+      - env_file          # entrypoint reads DEBUG from here to pick its log level
     environment:
       - PYTHONPATH=/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,6 @@ services:
       - /var/log/compassvpn:/var/log/compassvpn:ro
       - "./shared_lib:/shared_lib:ro"
     environment:
-      - LOG_LEVEL=warn   # WARN baseline like the rest of the stack (DEBUG-independent)
       - PYTHONPATH=/
 
   # Runs Grafana Alloy: scrapes the local metrics (node-exporter, xray-config,

--- a/xray-exporter/Dockerfile
+++ b/xray-exporter/Dockerfile
@@ -3,10 +3,10 @@ FROM alpine:3.22.4
 RUN apk add --no-cache wget && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then arch="amd64"; elif [ "$ARCH" = "aarch64" ]; then arch="arm64"; else echo "Unsupported architecture" && exit 1; fi && \
-    wget -O /xray-exporter https://github.com/compassvpn/xray-exporter/releases/download/v0.2.0/xray-exporter-linux-${arch} && \
+    wget -O /xray-exporter https://github.com/compassvpn/xray-exporter/releases/download/v0.4.0/xray-exporter-linux-${arch} && \
     chmod +x /xray-exporter && \
     apk del wget
 
 EXPOSE 9550
 
-CMD ["/xray-exporter", "--xray-endpoint", "xray:54321", "--log-path", "/var/log/compassvpn/xray_access.log"] 
+CMD ["/xray-exporter", "--xray-endpoint", "xray:54321", "--log-path", "/var/log/compassvpn/xray_access.log", "--log-level", "warn"]

--- a/xray-exporter/Dockerfile
+++ b/xray-exporter/Dockerfile
@@ -7,6 +7,10 @@ RUN apk add --no-cache wget && \
     chmod +x /xray-exporter && \
     apk del wget
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 9550
 
-CMD ["/xray-exporter", "--xray-endpoint", "xray:54321", "--log-path", "/var/log/compassvpn/xray_access.log", "--log-level", "warn"]
+# entrypoint picks the --log-level from the DEBUG flag in env_file
+CMD ["/entrypoint.sh"]

--- a/xray-exporter/entrypoint.sh
+++ b/xray-exporter/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Follow the stack's DEBUG flag (read from the mounted env_file): debug when it's
+# on, warn otherwise. Normalized the same way as the nginx/xray entrypoints so a
+# stray capital or quotes still work.
+DEBUG=$(printf '%s' "${DEBUG:-false}" | tr -d "\"'" | tr '[:upper:]' '[:lower:]')
+if [ "$DEBUG" = "true" ]; then
+    LOG_LEVEL=debug
+else
+    LOG_LEVEL=warn
+fi
+
+exec /xray-exporter \
+    --xray-endpoint xray:54321 \
+    --log-path /var/log/compassvpn/xray_access.log \
+    --log-level "$LOG_LEVEL"


### PR DESCRIPTION
You added a `--log-level` flag to xray-exporter (v0.3.0; v0.4.0 is latest), so this puts it to use.

**Bump + use the flag**
- Dockerfile pulls `v0.4.0` instead of `v0.2.0`.
- Removed the `LOG_LEVEL=warn` compose env from #107 — it was a no-op on v0.2.0 (binary ignored it).

**Make it follow DEBUG** (default warn, debug when `DEBUG=true` in env_file)
- small `entrypoint.sh` reads `DEBUG` and runs the exporter with `--log-level debug|warn`, normalized the same way as the nginx/xray entrypoints (handles `True`/`TRUE`/quotes).
- `env_file` is now mounted into the service so the entrypoint can see `DEBUG`.

So xray-exporter now behaves like the rest of the stack: quiet (warn) by default — no more `info` startup chatter — and verbose when you flip `DEBUG=true`.

Tradeoff worth noting: mounting `env_file` pulls the stack secrets into this container just to read one boolean (not strictly least-privilege). Fine here since logs/containers are admin-only; the alternative was a deploy-time `.env` route, which we skipped. node-exporter was intentionally left as-is (stock image, static warn).

Verified: `bash -n` on the entrypoint, compose YAML parses, level logic checked (`true/True/"true"` → debug; everything else → warn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)