### PR TITLE
bump xray-exporter to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Creates `config.json`, monitors configurations, and export Xray configurations v
 ### `xray`
 Reads `config.json` from the **xray-config** service and runs the Xray-core.
 
-### `v2ray-exporter`
-Exports V2Ray/Xray configuration metrics.
+### `xray-exporter`
+Reads Xray's access log and gRPC stats API and exposes them as Prometheus metrics on `:9550`. Also downloads the GeoIP databases on startup to geo-enrich destination metrics.
 
 ### `node-exporter`
 Prometheus Node Exporter that collects all critical metrics of the agent machine.
@@ -67,7 +67,7 @@ Prometheus Node Exporter that collects all critical metrics of the agent machine
 NGINX webserver to manage Xray inbounds and fallbacks, enhancing both performance and security.
 
 ### `metric-forwarder`
-Reads metrics from `xray-config`, `node-exporter`, and `v2ray-exporter` services and pushes them to a remote manager `Pushgateway` service or `Grafana Cloud Prometheus` endpoint.
+Reads metrics from `xray-config`, `node-exporter`, and `xray-exporter` services and pushes them to a remote manager `Pushgateway` service or `Grafana Cloud Prometheus` endpoint.
 
 ### `user-metrics`
 Tracks approximate active unique users across all configured inbounds and monitors blocked requests due to junk traffic, providing insights into bandwidth optimization.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,8 @@ services:
     depends_on:
       - xray
 
-  # Reads Xray's access log and exposes it as Prometheus metrics on :9550.
+  # Reads Xray's access log and exposes it as Prometheus metrics on :9550. Also
+  # pulls the GeoIP dbs from GitHub on startup (cached in the xray_geoip volume).
   xray-exporter:
     build:
       context: ./xray-exporter
@@ -144,11 +145,12 @@ services:
     restart: always
     <<: [*log-small, *hardening]
     cap_drop:
-      - ALL          # outbound scrape + read-only log + :9550; no caps needed
+      - ALL          # outbound scrape + GeoIP download + read-only log + :9550; no caps needed
     depends_on:
       - xray
     volumes:
       - /var/log/compassvpn:/var/log/compassvpn:ro
+      - "xray_geoip:/geoip"   # cache the downloaded GeoIP dbs
       - "./shared_lib:/shared_lib:ro"
     env_file:
       - env_file          # entrypoint reads DEBUG from here to pick its log level
@@ -215,3 +217,6 @@ services:
 # Shared cert store: xray-config writes here (acme.sh), xray and nginx read from it.
 volumes:
   acme:
+  # GeoIP dbs the xray-exporter downloads on startup - kept so we don't re-fetch
+  # them from GitHub on every restart.
+  xray_geoip:

--- a/xray-exporter/Dockerfile
+++ b/xray-exporter/Dockerfile
@@ -1,11 +1,16 @@
 FROM alpine:3.22.4
 
-RUN apk add --no-cache wget && \
+# keep ca-certificates around after dropping wget - the exporter needs it to
+# fetch the GeoIP dbs over https on startup
+RUN apk add --no-cache ca-certificates wget && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then arch="amd64"; elif [ "$ARCH" = "aarch64" ]; then arch="arm64"; else echo "Unsupported architecture" && exit 1; fi && \
-    wget -O /xray-exporter https://github.com/compassvpn/xray-exporter/releases/download/v0.5.0/xray-exporter-linux-${arch} && \
+    wget -O /xray-exporter https://github.com/compassvpn/xray-exporter/releases/download/v0.6.0/xray-exporter-linux-${arch} && \
     chmod +x /xray-exporter && \
     apk del wget
+
+# where the exporter caches the GeoIP dbs it downloads (volume-backed in compose)
+RUN mkdir -p /geoip
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/xray-exporter/entrypoint.sh
+++ b/xray-exporter/entrypoint.sh
@@ -9,7 +9,11 @@ else
     LOG_LEVEL=warn
 fi
 
+# --user-traffic-metrics: per-user byte counters (one series per user), on by choice.
+# --geoip-dir: where the GeoIP dbs get cached.
 exec /xray-exporter \
     --xray-endpoint xray:54321 \
+    --user-traffic-metrics \
     --log-path /var/log/compassvpn/xray_access.log \
+    --geoip-dir /geoip \
     --log-level "$LOG_LEVEL"


### PR DESCRIPTION
Bumps xray-exporter 0.5.0 -> 0.6.0.

- turns on per-user traffic metrics (`--user-traffic-metrics`)
- adds `ca-certificates` + an `xray_geoip` volume so the GeoIP dbs it now pulls from GitHub on startup actually work and persist across restarts
- finishes the `v2ray-exporter` -> `xray-exporter` rename in the README

heads up: per-user metrics are one series per user and get forwarded to remote Grafana, so cardinality goes up a bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)