### PR TITLE
self-heal deaf xray ports + stop nginx churning the hu path

### DIFF
--- a/nginx/tls_servers.conf.template
+++ b/nginx/tls_servers.conf.template
@@ -26,6 +26,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
+        # Match the xhttp locations; the 60s default cut every quiet tunnel
+        # each minute, hammering the upstream port with reconnects.
+        proxy_read_timeout 315;
+        proxy_socket_keepalive on;
     }
 
     # Forwards this path requests to xray (cdn).
@@ -41,6 +45,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
+        proxy_read_timeout 315;
+        proxy_socket_keepalive on;
     }
 
     include /etc/nginx/locations.d/2053/replicas.conf;

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -93,6 +93,8 @@ def _nginx_location_block(path: str, xray_port: int, template: str) -> str:
             f'        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n'
             f'        proxy_set_header Host $host;\n'
             f'        proxy_redirect off;\n'
+            f'        proxy_read_timeout 315;\n'
+            f'        proxy_socket_keepalive on;\n'
             f'    }}'
         )
     if template == "xhttp":

--- a/xray/Dockerfile
+++ b/xray/Dockerfile
@@ -11,7 +11,9 @@ COPY ./start_xray.sh /start_xray.sh
 COPY ./stop_xray.sh /stop_xray.sh
 
 COPY wg_monit /wg_monit
-COPY ./xray_monit /etc/monit.d/xray
+# Template only: the entrypoint renders it to /etc/monit.d/xray with one port
+# check per inbound taken from the generated config.
+COPY ./xray_monit /xray_monit
 
 COPY entrypoint.sh entrypoint.sh
 

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -2,6 +2,10 @@
 
 rm -f /run/*.pid
 
+# monit configs (xray + wg watchdogs) are rendered into this directory at
+# runtime; nothing creates it at build time anymore.
+mkdir -p /etc/monit.d
+
 # Normalize DEBUG (accept True/TRUE/"true") to match the Python services.
 DEBUG=$(printf '%s' "${DEBUG:-false}" | tr -d "\"'" | tr '[:upper:]' '[:lower:]')
 if [ "$DEBUG" = "true" ]; then
@@ -114,6 +118,27 @@ if ! xray -test -config /etc/xray/config.json; then
     exit 1
 fi
 
+# A process check alone misses a wedged listener: an inbound can stop
+# accepting connections while the xray process stays alive (seen in the wild
+# with httpupgrade under junk traffic - the port's accept queue fills up and
+# every new connection times out). Render the monit config from the template
+# plus one TCP connect check per inbound port, so monit also restarts xray
+# when a port goes deaf. "for 3 cycles" (~90s) tolerates brief load spikes.
+generate_monit_config() {
+    {
+        cat /xray_monit
+        jq -r '
+            [ .inbounds[]
+              | select((.listen // "0.0.0.0") == "0.0.0.0" or .listen == "127.0.0.1")
+              | .port
+              | select(type == "number") ]
+            | unique | .[]
+            | "  if failed host 127.0.0.1 port \(.) type tcp for 3 cycles then restart"
+        ' /etc/xray/config.json
+    } > /etc/monit.d/xray
+}
+generate_monit_config
+
 # Start Xray immediately so xray-config can test it
 /start_xray.sh
 
@@ -127,6 +152,12 @@ config_watcher() {
         new=$(curl -sf "$XRAY_CONFIG_URL") || continue
         if [ "$new" != "$(cat /etc/xray/config.json)" ]; then
             printf '%s' "$new" > /etc/xray/config.json
+            # The inbound ports may have changed (e.g. a TLS inbound dropped
+            # after a cert problem); re-render the port checks and make monit
+            # re-read them, otherwise a check on a removed port would restart
+            # xray forever.
+            generate_monit_config
+            kill -HUP "$(pidof monit)" 2>/dev/null
             if [ -f /run/xray.pid ]; then
                 kill -HUP "$(cat /run/xray.pid)" && echo "xray config updated and reloaded"
             fi

--- a/xray/xray_monit
+++ b/xray/xray_monit
@@ -1,3 +1,7 @@
+# Template: the entrypoint copies this to /etc/monit.d/xray and appends one
+# "if failed host 127.0.0.1 port N ..." line per inbound port, so xray is
+# restarted not only when the process dies but also when a listener stops
+# accepting connections while the process stays alive.
 check process xray with pidfile "/run/xray.pid"
   start program = "/start_xray.sh"
   stop program = "/stop_xray.sh"


### PR DESCRIPTION
xray sometimes keeps running while one inbound port stops accepting connections (hit it live on port 8022 / vless-hu-tls-cdn: nginx logs `upstream timed out (110) ... connecting to ... :8022` while the other ports still answer). monit only watched the process and compose has no healthchecks, so nothing noticed - the config stayed dead until a manual `./agent.sh start`.

what this does:

- entrypoint renders `/etc/monit.d/xray` from the template + one tcp connect check per inbound port (read from the fetched config with jq). port stops answering for ~90s -> monit restarts xray. config watcher re-renders the checks + HUPs monit on config change so a removed inbound can't leave a stale check that restarts xray forever.
- nginx hu locations: `proxy_read_timeout 315` (default 60s was cutting every quiet tunnel each minute -> nonstop reconnect churn on that port) + `proxy_socket_keepalive on` so dead upstream conns get cleaned up. same in the replica generator.

the port wedge itself is an xray-core bug we can't fix here - this makes the node notice and recover in ~2min instead of staying broken, and removes most of the churn that triggers it.

tested: monit -t on rendered config; live monit in alpine (deaf port -> exactly 1 restart, no flap after recovery); on a real node a fake failing port check restarted xray in 3 cycles; rendered nginx config passes nginx -t in the repo's image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)