### PR TITLE
heal deaf inbounds surgically instead of restarting all of xray

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,11 @@
 x-public-tuned: &public-tuned
   ulimits:
     nofile:
-      soft: 65535
-      hard: 65535
+      # Way above what normal load needs: xray's httpupgrade listener dies
+      # for good if accept() ever hits EMFILE (leaked half-open handshakes
+      # fill the fd table), so keep that ceiling far away.
+      soft: 1048576
+      hard: 1048576
   # These sysctls are per-network-namespace, so they apply only inside the
   # container - intentionally separate from the host values in agent.yml
   # (don't delete them thinking they're duplicates).

--- a/xray/Dockerfile
+++ b/xray/Dockerfile
@@ -9,6 +9,7 @@ RUN wget -O /usr/share/xray/geosite_IR.dat https://github.com/chocolate4u/Iran-v
 
 COPY ./start_xray.sh /start_xray.sh
 COPY ./stop_xray.sh /stop_xray.sh
+COPY ./heal_inbound.sh /heal_inbound.sh
 
 COPY wg_monit /wg_monit
 # Template only: the entrypoint renders it to /etc/monit.d/xray with one port

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -122,18 +122,24 @@ fi
 # accepting connections while the xray process stays alive (seen in the wild
 # with httpupgrade under junk traffic - the port's accept queue fills up and
 # every new connection times out). Render the monit config from the template
-# plus one TCP connect check per inbound port, so monit also restarts xray
-# when a port goes deaf. "for 3 cycles" (~90s) tolerates brief load spikes.
+# plus one TCP connect check per inbound port. A deaf port gets healed
+# surgically (/heal_inbound.sh re-adds just that inbound via the xray API, no
+# impact on other inbounds); only the API inbound itself (doko) falls back to
+# a full restart since a dead API can't heal anything. "for 3 cycles" (~90s)
+# tolerates brief load spikes; "repeat" re-fires the heal so it can escalate.
 generate_monit_config() {
     {
         cat /xray_monit
         jq -r '
             [ .inbounds[]
               | select((.listen // "0.0.0.0") == "0.0.0.0" or .listen == "127.0.0.1")
-              | .port
-              | select(type == "number") ]
-            | unique | .[]
-            | "  if failed host 127.0.0.1 port \(.) type tcp for 3 cycles then restart"
+              | select((.port | type) == "number") ]
+            | unique_by(.port) | .[]
+            | if .tag == "doko" then
+                "  if failed host 127.0.0.1 port \(.port) type tcp with timeout 10 seconds for 3 cycles then restart"
+              else
+                "  if failed host 127.0.0.1 port \(.port) type tcp with timeout 10 seconds for 3 cycles then exec \"/heal_inbound.sh \(.port)\" repeat every 3 cycles"
+              end
         ' /etc/xray/config.json
     } > /etc/monit.d/xray
 }

--- a/xray/heal_inbound.sh
+++ b/xray/heal_inbound.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Surgical heal for a single deaf inbound, called by monit when a port stops
+# accepting connections: remove + re-add just that inbound through the xray
+# API (the doko inbound on 54321), so every other inbound and its users are
+# untouched. Falls back to a full restart when the API path fails or the same
+# port goes deaf twice within 5 minutes.
+
+port="$1"
+case "$port" in
+    ''|*[!0-9]*) echo "heal_inbound: bad port '$port'"; exit 1;;
+esac
+
+API="127.0.0.1:54321"
+marker="/tmp/heal_inbound_${port}.last"
+now=$(date +%s)
+
+# Second failure in a short window means the surgical heal isn't holding -
+# escalate to the sledgehammer.
+if [ -f "$marker" ] && [ $(( now - $(cat "$marker") )) -lt 300 ]; then
+    echo "heal_inbound: port $port deaf again within 5 minutes; full restart"
+    rm -f "$marker"
+    monit restart xray
+    exit 0
+fi
+echo "$now" > "$marker"
+
+tmp="/tmp/heal_inbound_${port}.json"
+jq "{inbounds: [.inbounds[] | select(.port == ${port})]}" /etc/xray/config.json > "$tmp"
+if [ "$(jq '.inbounds | length' "$tmp")" -eq 0 ]; then
+    # Stale check on a port that left the config; the re-rendered monit
+    # config drops the check on the next reload, nothing to heal here.
+    echo "heal_inbound: port $port not in config.json; nothing to heal"
+    exit 0
+fi
+
+if xray api rmi --server="$API" "$tmp" && xray api adi --server="$API" "$tmp"; then
+    echo "heal_inbound: inbound on port $port removed and re-added"
+    exit 0
+fi
+
+echo "heal_inbound: API heal failed for port $port; full restart"
+monit restart xray

--- a/xray/xray_monit
+++ b/xray/xray_monit
@@ -1,7 +1,7 @@
 # Template: the entrypoint copies this to /etc/monit.d/xray and appends one
-# "if failed host 127.0.0.1 port N ..." line per inbound port, so xray is
-# restarted not only when the process dies but also when a listener stops
-# accepting connections while the process stays alive.
+# "if failed host 127.0.0.1 port N ..." line per inbound port, so a listener
+# that stops accepting connections while the process stays alive gets healed
+# too (surgically via /heal_inbound.sh; full restart only as fallback).
 check process xray with pidfile "/run/xray.pid"
   start program = "/start_xray.sh"
   stop program = "/stop_xray.sh"


### PR DESCRIPTION
follow-up to #110. the watchdog works, but each heal is a full xray restart that drops every user - shows up as bandwidth dips in grafana every time a port wedges.

xray's api (the doko inbound on 54321, already enabled) can remove + re-add a single inbound at runtime. so:

- deaf port -> `/heal_inbound.sh <port>`: `xray api rmi` + `adi` for just that inbound. its users were already dead; nobody else notices. same process, no restart.
- falls back to `monit restart xray` when the api calls fail or the same port goes deaf twice within 5 min (heal isn't holding -> sledgehammer).
- the api port itself (doko) keeps the plain restart action - a dead api can't heal anything.
- port check timeout bumped to 10s so heavy load doesn't cause false alarms.
- nofile raised 65535 -> 1M for xray/nginx: the wedge fires when accept() hits EMFILE (leaked half-open handshakes fill the fd table), so keep that ceiling far away and it (about) never triggers at all.

tested on teddysun/xray:26.3.27: heal bounces only the target inbound (xray pid unchanged, other inbounds keep serving), escalation + stale-port paths verified, rendered monit config passes monit -t, compose config validates.

deploy note: watch `docker compose logs xray | grep heal_inbound` - heals should appear there with no matching dip in grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)