### PR TITLE
use direct subdomain for reality links

### DIFF
--- a/xray-config/inbounds.json
+++ b/xray-config/inbounds.json
@@ -116,7 +116,7 @@
   },
   {
     "name": "vless-tcp-reality-direct",
-    "link": "vless://$config_id@$server_ip:2083?type=tcp&security=reality&flow=xtls-rprx-vision&fp=chrome&pbk=$reality_public_key&sid=2083&sni=$reality_sni&spx=%2F#vless-tcp-reality-direct",
+    "link": "vless://$config_id@$direct_subdomain:2083?type=tcp&security=reality&flow=xtls-rprx-vision&fp=chrome&pbk=$reality_public_key&sid=2083&sni=$reality_sni&spx=%2F#vless-tcp-reality-direct",
     "cloudflare": false,
     "inbound": {
       "tag": "vless-tcp-reality-direct",
@@ -159,7 +159,7 @@
   },
   {
     "name": "vless-xhttp-reality-direct",
-    "link": "vless://$config_id@$server_ip:2087?type=xhttp&mode=auto&path=%2F$nginx_path&security=reality&fp=chrome&pbk=$reality_public_key&sid=2087&sni=$reality_sni&spx=%2F#vless-xhttp-reality-direct",
+    "link": "vless://$config_id@$direct_subdomain:2087?type=xhttp&mode=auto&path=%2F$nginx_path&security=reality&fp=chrome&pbk=$reality_public_key&sid=2087&sni=$reality_sni&spx=%2F#vless-xhttp-reality-direct",
     "cloudflare": false,
     "inbound": {
       "tag": "vless-xhttp-reality-direct",


### PR DESCRIPTION
Both reality inbounds (`vless-tcp-reality-direct`, `vless-xhttp-reality-direct`) now dial `$direct_subdomain` instead of the raw `$server_ip`, matching every other direct inbound.

- Links survive a server IP change (DNS follows).
- Consistent with the rest (reality was the only holdout on a bare IP).
- SNI stays the reality target (`$reality_sni`), so REALITY behavior is unchanged; only the connect host in the share link changes.

Uses the unproxied `-direct` subdomain, which is required for REALITY (the CF-proxied one would break it).

Note: this ties the reality inbounds to CF DNS being configured (on a non-CF deployment `direct_subdomain` is empty). That is already true for every other direct inbound, so no new constraint in practice for this stack.