### PR TITLE
don't hardcode docker0 IP for node-exporter listener

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -27,7 +27,8 @@
       - "127.0.0.53"
 
     # Ports opened on the host firewall. 9100 (node-exporter) is intentionally NOT
-    # here - it's reached only over the internal Docker network, never the host.
+    # here - it listens on the host, but only the local Docker bridges can reach
+    # it; the default-deny keeps it closed to the internet.
     required_ports:
       - 80
       - 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,8 +189,11 @@ services:
   # Standard host metrics (CPU, memory, disk, network). Must share the host
   # network namespace: /proc/net is a symlink to /proc/self/net, so the netdev
   # collector reports whatever netns it runs in - from an isolated netns it
-  # would only see the container's own veth, not the host NICs. It binds to
-  # the docker0 IP only, so nothing is reachable from outside the host.
+  # would only see the container's own veth, not the host NICs. It listens on
+  # all interfaces because the docker0 IP is not stable across hosts (Docker
+  # picks the next free pool if 172.17.0.0/16 is taken); UFW's default-deny
+  # keeps 9100 unreachable from outside, and it's not a published port so
+  # Docker's iptables bypass doesn't apply.
   node-exporter:
     image: prom/node-exporter:v1.11.1
     restart: always
@@ -221,7 +224,7 @@ services:
       - '--collector.time'
       - '--collector.stat'
       - '--collector.pressure'
-      - "--web.listen-address=172.17.0.1:9100" # docker0 only; reached by metric-forwarder via host.docker.internal
+      - "--web.listen-address=:9100" # blocked externally by UFW; reached by metric-forwarder via host.docker.internal
 
 # Shared cert store: xray-config writes here (acme.sh), xray and nginx read from it.
 volumes:


### PR DESCRIPTION
Follow-up to #116. One server (Azure) had node-exporter in a restart loop:

```
listen tcp 172.17.0.1:9100: bind: cannot assign requested address
```

docker0 there is `172.18.0.1` - no daemon.json, Docker just picked the next address pool because 172.17.0.0/16 was already taken when dockerd first started. So the docker0 IP can't be assumed.

Fix: listen on `:9100`. Safety stays the same:
- UFW is default-deny incoming and 9100 is not in `required_ports`, so it's closed to the internet
- it's a plain host listener, not a docker-published port, so Docker's UFW/iptables bypass doesn't apply
- metric-forwarder keeps scraping via `host.docker.internal` (host-gateway), which follows whatever IP the bridge actually has

Verify on the Azure box after update: `curl -s localhost:9100/metrics | head` on the host, and the two network panels in Grafana ~10 min later.