### PR TITLE
scrape all metrics over loopback

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -26,9 +26,9 @@
       - "1.1.1.2"
       - "127.0.0.53"
 
-    # Ports opened on the host firewall. 9100 (node-exporter) is intentionally NOT
-    # here - it listens on the host, but only the local Docker bridges can reach
-    # it; the default-deny keeps it closed to the internet.
+    # Ports opened on the host firewall. The metrics ports (9100, 5000, 9550) are
+    # intentionally NOT here - they are bound to loopback and scraped over loopback
+    # by the host-network metric-forwarder, so no firewall rule is needed.
     required_ports:
       - 80
       - 8080

--- a/agent.yml
+++ b/agent.yml
@@ -26,9 +26,9 @@
       - "1.1.1.2"
       - "127.0.0.53"
 
-    # Ports opened on the host firewall. The metrics ports (9100, 5000, 9550) are
-    # intentionally NOT here - they are bound to loopback and scraped over loopback
-    # by the host-network metric-forwarder, so no firewall rule is needed.
+    # Ports opened on the host firewall. The metrics ports (29100, 25000, 29550)
+    # are intentionally NOT here - they are bound to loopback and scraped over
+    # loopback by the host-network metric-forwarder, so no firewall rule is needed.
     required_ports:
       - 80
       - 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,12 @@ services:
       - "./env_file:/root/env_file:ro"
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
     ports:
-      - "127.0.0.1:5000:5000"   # metrics for the host-network metric-forwarder; loopback only, not reachable from outside
+      # Metrics for the host-network metric-forwarder; loopback only, not
+      # reachable from outside. Host port 25000, not 5000: 5000 is a common
+      # default (Flask, docker registry), and anything below 32768 stays out
+      # of the kernel's ephemeral port range so outbound connections can
+      # never squat the port at deploy time.
+      - "127.0.0.1:25000:5000"
 
   # The actual proxy - this is what clients connect to and where all the VPN
   # traffic flows. In "warp" mode it also brings up a WireGuard tunnel for egress.
@@ -161,7 +166,7 @@ services:
       - "xray_geoip:/geoip"   # cache the downloaded GeoIP dbs
       - "./shared_lib:/shared_lib:ro"
     ports:
-      - "127.0.0.1:9550:9550"   # metrics for the host-network metric-forwarder; loopback only, not reachable from outside
+      - "127.0.0.1:29550:9550"   # metrics for the host-network metric-forwarder; loopback only (29550: see the port note on xray-config)
     env_file:
       - env_file          # entrypoint reads DEBUG from here to pick its log level
     environment:
@@ -230,7 +235,7 @@ services:
       - '--collector.time'
       - '--collector.stat'
       - '--collector.pressure'
-      - "--web.listen-address=127.0.0.1:9100" # loopback only; scraped by the host-network metric-forwarder
+      - "--web.listen-address=127.0.0.1:29100" # loopback only; 29100 not 9100 so an apt-installed node-exporter can't collide
 
 # Shared cert store: xray-config writes here (acme.sh), xray and nginx read from it.
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,9 @@ x-hardening: &hardening
 services:
 
   # Brain of the stack: generates the Xray config, fetches/renews TLS certs via
-  # acme.sh + the Cloudflare API, and runs the config self-tests. Only talks to
-  # the other containers over the internal network - no published ports.
+  # acme.sh + the Cloudflare API, and runs the config self-tests. Talks to the
+  # other containers over the internal network; its only published port is the
+  # metrics endpoint, and that is bound to the host's loopback.
   xray-config:
     build:
       context: ./xray-config
@@ -69,6 +70,8 @@ services:
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/root/env_file:ro"
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
+    ports:
+      - "127.0.0.1:5000:5000"   # metrics for the host-network metric-forwarder; loopback only, not reachable from outside
 
   # The actual proxy - this is what clients connect to and where all the VPN
   # traffic flows. In "warp" mode it also brings up a WireGuard tunnel for egress.
@@ -157,18 +160,24 @@ services:
       - /var/log/compassvpn:/var/log/compassvpn:ro
       - "xray_geoip:/geoip"   # cache the downloaded GeoIP dbs
       - "./shared_lib:/shared_lib:ro"
+    ports:
+      - "127.0.0.1:9550:9550"   # metrics for the host-network metric-forwarder; loopback only, not reachable from outside
     env_file:
       - env_file          # entrypoint reads DEBUG from here to pick its log level
     environment:
       - PYTHONPATH=/
 
   # Runs Grafana Alloy: scrapes the local metrics (node-exporter, xray-config,
-  # xray-exporter) and ships them off to the remote Grafana endpoint.
+  # xray-exporter) and ships them off to the remote Grafana endpoint. Shares the
+  # host network namespace so every scrape target is 127.0.0.1: loopback traffic
+  # never touches UFW, Docker's bridge subnets, or the host INPUT chain, all of
+  # which vary per host and have broken the node-exporter scrape before.
   metric-forwarder:
     build:
       context: ./metric-forwarder
       dockerfile: Dockerfile
     restart: always
+    network_mode: host
     <<: [*log-small, *hardening]
     cap_drop:
       - ALL          # pure outbound Alloy forwarder; no caps needed
@@ -180,8 +189,6 @@ services:
     volumes:
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/env_file:ro"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"   # reach node-exporter on the host netns (docker0)
     depends_on:
       - xray-config
       - node-exporter
@@ -189,11 +196,10 @@ services:
   # Standard host metrics (CPU, memory, disk, network). Must share the host
   # network namespace: /proc/net is a symlink to /proc/self/net, so the netdev
   # collector reports whatever netns it runs in - from an isolated netns it
-  # would only see the container's own veth, not the host NICs. It listens on
-  # all interfaces because the docker0 IP is not stable across hosts (Docker
-  # picks the next free pool if 172.17.0.0/16 is taken); UFW's default-deny
-  # keeps 9100 unreachable from outside, and it's not a published port so
-  # Docker's iptables bypass doesn't apply.
+  # would only see the container's own veth, not the host NICs. It binds to
+  # loopback only: the metric-forwarder shares the host netns and scrapes it
+  # over 127.0.0.1, and nothing else - containers, VPN clients proxying to the
+  # server's own IP, or the internet - can reach loopback at all.
   node-exporter:
     image: prom/node-exporter:v1.11.1
     restart: always
@@ -224,7 +230,7 @@ services:
       - '--collector.time'
       - '--collector.stat'
       - '--collector.pressure'
-      - "--web.listen-address=:9100" # blocked externally by UFW; reached by metric-forwarder via host.docker.internal
+      - "--web.listen-address=127.0.0.1:9100" # loopback only; scraped by the host-network metric-forwarder
 
 # Shared cert store: xray-config writes here (acme.sh), xray and nginx read from it.
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,10 +72,10 @@ services:
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
     ports:
       # Metrics for the host-network metric-forwarder; loopback only, not
-      # reachable from outside. Host port 25000, not 5000: 5000 is a common
-      # default (Flask, docker registry), and anything below 32768 stays out
-      # of the kernel's ephemeral port range so outbound connections can
-      # never squat the port at deploy time.
+      # reachable from outside. Host port 25000 rather than 5000: 5000 is a
+      # common default (Flask, docker registry), and ports below 32768 sit
+      # outside the kernel's ephemeral range, so an outbound connection can
+      # never be holding the port when the proxy tries to bind it.
       - "127.0.0.1:25000:5000"
 
   # The actual proxy - this is what clients connect to and where all the VPN
@@ -174,9 +174,10 @@ services:
 
   # Runs Grafana Alloy: scrapes the local metrics (node-exporter, xray-config,
   # xray-exporter) and ships them off to the remote Grafana endpoint. Shares the
-  # host network namespace so every scrape target is 127.0.0.1: loopback traffic
-  # never touches UFW, Docker's bridge subnets, or the host INPUT chain, all of
-  # which vary per host and have broken the node-exporter scrape before.
+  # host network namespace so every scrape target is 127.0.0.1: loopback behaves
+  # the same on every host, while container-to-host traffic crosses the host
+  # INPUT chain and depends on the firewall rules and Docker's bridge subnets,
+  # both of which vary per host.
   metric-forwarder:
     build:
       context: ./metric-forwarder

--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -105,7 +105,7 @@ prometheus.remote_write "default" {{
 
 prometheus.scrape "node_exporter" {{
   targets = [{{
-    __address__ = "127.0.0.1:9100",
+    __address__ = "127.0.0.1:29100",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/metrics"
@@ -136,7 +136,7 @@ prometheus.relabel "node_exporter" {{
 
 prometheus.scrape "xray" {{
   targets = [{{
-    __address__ = "127.0.0.1:5000",
+    __address__ = "127.0.0.1:25000",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/metrics"
@@ -157,7 +157,7 @@ prometheus.relabel "xray" {{
 
 prometheus.scrape "xray_exporter" {{
   targets = [{{
-    __address__ = "127.0.0.1:9550",
+    __address__ = "127.0.0.1:29550",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/scrape"

--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -105,7 +105,7 @@ prometheus.remote_write "default" {{
 
 prometheus.scrape "node_exporter" {{
   targets = [{{
-    __address__ = "host.docker.internal:9100",
+    __address__ = "127.0.0.1:9100",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/metrics"
@@ -136,7 +136,7 @@ prometheus.relabel "node_exporter" {{
 
 prometheus.scrape "xray" {{
   targets = [{{
-    __address__ = "xray-config:5000",
+    __address__ = "127.0.0.1:5000",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/metrics"
@@ -157,7 +157,7 @@ prometheus.relabel "xray" {{
 
 prometheus.scrape "xray_exporter" {{
   targets = [{{
-    __address__ = "xray-exporter:9550",
+    __address__ = "127.0.0.1:9550",
   }}]
   scrape_interval = "5m"
   metrics_path    = "/scrape"


### PR DESCRIPTION
node_* metrics were missing from most servers. root cause: alloy scraped node-exporter at host.docker.internal:9100, and that container->host traffic goes through the host INPUT chain where ufw's default-deny drops it. whether it worked depended on per-host state (docker address pool, firewall), hence the randomness. confirmed on a debian 13 box: the scrape times out, and a ufw allow for the docker range fixes it instantly.

instead of opening 9100, this moves the whole metrics path onto loopback so it can't depend on host state:

- metric-forwarder runs on the host network; all three scrape targets are 127.0.0.1
- node-exporter binds 127.0.0.1:29100 - unreachable from containers, VPN clients proxying to the server's own IP, or outside
- xray-config and xray-exporter metrics are published on 127.0.0.1 only (host ports 25000/29550)
- no firewall rule needed at all

host ports are 25000/29100/29550 rather than the defaults: 5000 collides with flask/docker-registry, 9100 with any host node-exporter, and everything below 32768 stays out of the kernel's ephemeral range so outbound connections can't squat a port at deploy time. container-internal ports are unchanged (nginx/xray still fetch config from xray-config:5000 over the bridge).

tested on a previously-broken debian 13 server: with no ufw rule, all three targets return 200 over loopback right after deploy. note xray-config takes a minute to start serving its metrics after boot (cert/config work first) - connections reset until then, which is fine at a 5m scrape interval.