### PR TITLE
accept DoT URLs and plain IPv4 for CUSTOM_DNS

### DIFF
--- a/env_file.example
+++ b/env_file.example
@@ -39,8 +39,9 @@ NGINX_PATH=compass
 # disguise the reality inbound.
 FAKE_WEBSITE=www.divar.ir
 
-# DNS resolver for outbound lookups: "default", "cf", "controld", or a full
-# https+local:// / quic+local:// URL.
+# DNS resolver for outbound lookups: "default", "cf", "controld", a full
+# https+local:// (DoH) / quic+local:// (DoQ) / tls+local:// (DoT) URL,
+# or a plain IPv4 address (UDP).
 CUSTOM_DNS=controld
 
 # true = verbose logging across all containers, plus xray DNS-query logging and

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -1,6 +1,7 @@
 import base64
 import copy
 import hashlib
+import ipaddress
 import json
 import re
 import string
@@ -740,14 +741,26 @@ class XrayConfig:
             elif custom_dns_config == "controld":
                 dns_server = "https+local://freedns.controld.com/no-ads-dating-drugs-gambling-malware-typo"
             elif custom_dns_config.startswith(
-                "https+local://"
-            ) or custom_dns_config.startswith("quic+local://"):
+                ("https+local://", "quic+local://", "tls+local://")
+            ):
                 dns_server = custom_dns_config
+            else:
+                # Plain UDP resolver, must be a valid IPv4 address
+                try:
+                    ipaddress.IPv4Address(custom_dns_config)
+                    dns_server = custom_dns_config
+                except ValueError:
+                    pass
             if dns_server:
                 self.xray_config["dns"] = {
                     "servers": [dns_server],
                     "queryStrategy": "UseIPv4",
                 }
+            else:
+                log.warning(
+                    f"CUSTOM_DNS value {custom_dns_config!r} is not a supported format; using default DNS",
+                    hypothesisId="CFG",
+                )
 
         # WARP configuration
         self.warps_ready = False


### PR DESCRIPTION
CUSTOM_DNS now also accepts `tls+local://` (DoT) URLs and bare IPv4 addresses (plain UDP resolver, validated before use). Both go into the same `dns` block as the existing DoH/DoQ formats.

Values that match no accepted format used to be silently ignored; now they log a warning naming the rejected value and fall back to default DNS (no dns block), same as before.

Also updated the CUSTOM_DNS comment in env_file.example.

Tested by generating configs with every accepted format plus an invalid value: dns block comes out right for each, warning fires on the invalid one, and `xray -test` (teddysun/xray:26.3.27, same image we build on) passes for the new formats.