### PR TITLE
pin public IP lookup to IPv4

### DIFF
--- a/shared_lib/network.py
+++ b/shared_lib/network.py
@@ -1,12 +1,19 @@
 import ipaddress
+import socket
 import requests
-from typing import Dict, Union
+import urllib3.util.connection as urllib3_connection
+from typing import Dict, List, Union
 
 from shared_lib.logger import log
 
 
 def get_public_ip(extra: bool = False) -> Union[str, Dict[str, str]]:
-    """Fetches the public IP and optionally country info from multiple providers."""
+    """Fetches the public IP and optionally country info from multiple providers.
+
+    Forces the lookup over IPv4. Providers echo back whichever family the
+    request arrived on, so on a dual-stack host the result would otherwise
+    flip to the public IPv6 - making the `instance` metric label unstable.
+    """
     # HTTPS-only: the IP/country result is interpolated into generated configs
     # and metric labels, so it must not be fetched over a plaintext channel an
     # on-path attacker could poison. ip-api.com's free endpoint is HTTP-only and
@@ -25,6 +32,21 @@ def get_public_ip(extra: bool = False) -> Union[str, Dict[str, str]]:
         },
     ]
 
+    # urllib3 picks the address family per connection, so on a dual-stack host
+    # these lookups can egress over IPv6 and the provider echoes back the v6
+    # address - flipping the `instance` label. Pin the resolver to IPv4 for the
+    # duration of the calls, then restore it.
+    original_gai_family = urllib3_connection.allowed_gai_family
+    urllib3_connection.allowed_gai_family = lambda: socket.AF_INET
+    try:
+        return _query_providers(providers, extra)
+    finally:
+        urllib3_connection.allowed_gai_family = original_gai_family
+
+
+def _query_providers(
+    providers: List[Dict[str, str]], extra: bool
+) -> Union[str, Dict[str, str]]:
     for provider in providers:
         # Defence-in-depth: never fall back to a plaintext endpoint.
         if not provider["url"].startswith("https://"):


### PR DESCRIPTION
## What

`get_public_ip` resolves the node's public IP by hitting geo-IP providers that echo back whichever address family the request arrived on. Now that the default network is dual-stack, these lookups can egress over IPv6, so the provider returns the public v6 and the resolved value flips.

That value is stamped as the `instance` label on every scrape (node-exporter, xray, xray-exporter), so affected nodes appear under their IPv6 across all dashboards even when there's no IPv6 inbound in use.

## Fix

Pin the resolver to IPv4 for the duration of the lookup (override urllib3's address-family selector), then restore it. Single source, so it fixes the label everywhere at once.

## Verify

On a dual-stack node, rebuild the forwarder and check the resolved value:

```
docker compose up -d --build metric-forwarder
docker exec agent-metric-forwarder-1 grep -i instance config.alloy
```

Should now show the v4. Existing v6-labeled samples age out over their retention window.