### PR TITLE
Point Docker at non-conflicting address pools

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -362,6 +362,41 @@
             executable: /bin/bash
           when: docker_check.rc != 0
 
+    # ---- docker network: non-conflicting address pools ---------------------
+    # Docker allocates bridge subnets from 172.16.0.0/12, which collides with
+    # VNets in that block (common on Azure) and wedges networking. Its built-in
+    # avoidance only covers subnets it auto-picks, not ones it's handed, so pin
+    # both out of that range into a quiet 10.x block: bip moves docker0,
+    # default-address-pools moves the compose network. Docker still skips any
+    # pool range already in use on the host, as a backstop. The trailing v6 ULA
+    # pool feeds the compose network's enable_ipv6 (internal-only, collision-safe
+    # by design), so both families source from here. Also tagged 'deploy' so a
+    # deploy-only run configures the daemon before it starts any containers.
+    - name: Point Docker at non-conflicting address pools
+      tags: [docker, deploy]
+      block:
+        - name: Write /etc/docker/daemon.json
+          ansible.builtin.copy:
+            dest: /etc/docker/daemon.json
+            mode: "0644"
+            content: |
+              {
+                "bip": "10.69.0.1/24",
+                "default-address-pools": [
+                  { "base": "10.70.0.0/16", "size": 24 },
+                  { "base": "10.169.0.0/16", "size": 24 },
+                  { "base": "10.199.0.0/16", "size": 24 },
+                  { "base": "fd00:c0:ffee::/48", "size": 64 }
+                ]
+              }
+          register: docker_daemon
+
+        - name: Restart Docker when the config changed
+          ansible.builtin.systemd_service:
+            name: docker
+            state: restarted
+          when: docker_daemon.changed
+
     # ---- identifier: a stable per-node label, generated once ---------------
     # Also tagged 'deploy' so a deploy-only run can't start containers without an
     # IDENTIFIER (the services hard-fail if it's missing). It's a no-op once set.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,12 +247,11 @@ volumes:
 
 # Give the default bridge IPv6 so the direct inbounds (reality on 2083/2087 and
 # 443) see real client v6 addresses via ip6tables DNAT, instead of collapsing
-# them to the bridge gateway 172.18.0.1 through docker-proxy. The ULA subnet is
-# internal-only (host<->container), unrelated to the server's public IPv6.
+# them to the bridge gateway through docker-proxy.
+#
+# Neither subnet is pinned here; both come from the daemon's address pools (set
+# in agent.yml): a host-local 10.x block for v4 that stays clear of the host's
+# own networks, and an internal-only ULA for v6. One source of truth.
 networks:
   default:
     enable_ipv6: true
-    ipam:
-      config:
-        - subnet: 172.18.0.0/16
-        - subnet: fd00:c0:ffee::/64


### PR DESCRIPTION
## Problem

Docker allocates its bridge subnets from `172.16.0.0/12`. On VMs whose VNet lives in that block (common on Azure) a bridge shadows a real route and wedges the host's networking.

Docker does have built-in avoidance ("attempts to avoid address prefixes already in use on the host"), but it only applies to subnets it **auto-picks**, never to ones it's **handed**. The stack pinned its own network to `172.18.0.0/16` (added in the IPv6 commit); an explicit subnet bypasses the check, so on a 172.18 VNet it landed straight on the host network. `docker0`, which is auto-allocated, dodged the host fine on its own, proof the auto path was never the problem. The pin was.

## Fix

Move all Docker addressing into `daemon.json` so compose only declares intent:

- `bip` pins `docker0` to a small `10.69.0.0/24`.
- `default-address-pools` puts the compose network's **v4** in `10.70.x` (with `10.169`/`10.199` as further pools) and its **v6** in the `fd00:c0:ffee::/48` ULA. Since these are pools, not pins, Docker's avoidance still works as a backstop within them. The first v6 `/64` handed out is `fd00:c0:ffee::/64`, the exact value the stack has today, so v6 doesn't actually change, it just sources from the daemon now.
- `docker-compose.yml` drops both subnet pins and keeps only `enable_ipv6: true`.

The v4 ranges are chosen far from where clouds cluster defaults (Azure 10.0/10.1, GCP 10.128/9, k8s 10.96/12). The v6 ULA is internal-only and collision-safe by design.

Runs after Docker install, before deploy (tagged `docker` + `deploy`); restarts Docker only when the file changed.

Note: avoidance (and this) sees only prefixes in use locally, so a peered subnet reachable only via the default route isn't detected; the range choices make that vanishingly unlikely. If a pool were somehow fully in use, network creation fails at `docker compose up`, so the deploy errors rather than breaking the host silently.