### PR TITLE
Update xray-knife to v10.1.1, tune flags, harden CSV parsing

### DIFF
--- a/shared_lib/system.py
+++ b/shared_lib/system.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import subprocess
 from typing import List, Optional, Dict, Mapping
@@ -64,23 +65,23 @@ def exec_command(
         raise e
 
 
-def csv_to_dict(filename: str) -> Dict[str, List[str]]:
-    """Converts a CSV file to a dictionary, skipping headers and malformed lines."""
-    data = {}
+def csv_to_dict(filename: str) -> Dict[str, Dict[str, str]]:
+    """Parses xray-knife's CSV output, keyed by config link.
+
+    Uses csv.DictReader so quoted fields (e.g. a `reason` that contains a
+    comma) are parsed by column name instead of by position, which a naive
+    split(",") would get wrong.
+    """
+    data: Dict[str, Dict[str, str]] = {}
     if os.path.exists(filename):
         try:
-            with open(filename, "r", encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
+            with open(filename, "r", encoding="utf-8", newline="") as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    link = row.get("link", "")
+                    if not link.startswith(("vmess://", "vless://")):
                         continue
-                    parts = line.split(",")
-                    # Skip header row or malformed lines
-                    if parts[0] == "link" or not parts[0].startswith(
-                        ("vmess://", "vless://")
-                    ):
-                        continue
-                    data[parts[0]] = parts
+                    data[link] = row
         except Exception as e:
             log.error(f"Error reading CSV {filename}: {e}", hypothesisId="SYS")
     return data

--- a/xray-config/Dockerfile
+++ b/xray-config/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache --virtual .build-deps wget unzip && \
         echo "Unsupported architecture: $ARCH" >&2; \
         exit 1; \
     fi && \
-    wget -L -O knife.zip "https://github.com/lilendian0x00/xray-knife/releases/download/v10.0.0/Xray-knife-linux-${arch_name}.zip" && \
+    wget -L -O knife.zip "https://github.com/lilendian0x00/xray-knife/releases/download/v10.1.1/Xray-knife-linux-${arch_name}.zip" && \
     unzip knife.zip && \
     mv ./xray-knife /usr/bin/ && \
     rm -f knife.zip LICENSE README.md && \

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -182,7 +182,7 @@ class XrayService:
                 "http",
                 "--thread",
                 "6",
-                "-d",
+                "--mdelay",
                 "10000",
                 # One retry so a transient blip does not flap a config to down
                 # for the whole cycle.
@@ -194,15 +194,15 @@ class XrayService:
                 # Skip the per-config real-IP lookup; unused (instance IP comes
                 # from get_public_ip) and it adds a request per config.
                 "--rip=false",
-                "-f",
+                "--file",
                 str(CONFIGS_CSV),
-                "-o",
+                "--out",
                 str(VALID_CSV),
-                "-x",
+                "--type",
                 "csv",
             ]
             if is_debug():
-                knife_cmd.append("-v")
+                knife_cmd.append("--verbose")
             exec_command(knife_cmd)
 
             self.valid_configs = csv_to_dict(str(VALID_CSV))

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -1,6 +1,6 @@
 import json
 import threading
-from typing import Dict, List, Optional, Union
+from typing import Dict, Optional, Union
 from flask import Flask, abort
 
 from config import config
@@ -24,7 +24,7 @@ def _prom_label_escape(value: object) -> str:
 class XrayService:
     def __init__(self) -> None:
         self.app: Flask = Flask(__name__)
-        self.valid_configs: Dict[str, List[str]] = {}
+        self.valid_configs: Dict[str, Dict[str, str]] = {}
         self.latest_metrics: str = ""
         self.instance_location_info: Optional[Union[str, Dict[str, str]]] = None
         self._shutdown_event: threading.Event = threading.Event()
@@ -75,7 +75,7 @@ class XrayService:
         def metrics():
             return self.latest_metrics
 
-    def update_metrics(self, configs: Dict[str, List[str]]) -> bool:
+    def update_metrics(self, configs: Dict[str, Dict[str, str]]) -> bool:
         if not self.instance_location_info:
             self.instance_location_info = get_public_ip(extra=True)
 
@@ -95,8 +95,8 @@ class XrayService:
         failed_count = 0
         for config_link, value in configs.items():
             try:
-                status = value[1]
-                delay = value[5]
+                status = value["status"]
+                delay = value["delay"]
 
                 config_info = parse_config_link(config_link)
                 labels = [

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -184,6 +184,16 @@ class XrayService:
                 "6",
                 "-d",
                 "10000",
+                # One retry so a transient blip does not flap a config to down
+                # for the whole cycle.
+                "--retries",
+                "1",
+                # We only test vmess/vless; pin the core instead of auto-detect.
+                "--core",
+                "xray",
+                # Skip the per-config real-IP lookup; unused (instance IP comes
+                # from get_public_ip) and it adds a request per config.
+                "--rip=false",
                 "-f",
                 str(CONFIGS_CSV),
                 "-o",


### PR DESCRIPTION
## Version bump (v10.0.0 -> v10.1.1)
Latest release. Asset names (`Xray-knife-linux-64.zip`, `Xray-knife-linux-arm64-v8a.zip`) match the existing download URL, so both amd64 and arm64 keep working. v10.1.x restores the Android arm64 build and loosens the Go build requirement to any 1.26.x; neither affects our prebuilt-binary usage.

## Flag tuning (run.py)
- `--retries 1`: a transient network blip no longer flaps a config to down for the whole 300s cycle.
- `--core xray`: we pre-filter to vmess/vless, so pin the core instead of relying on auto-detect.
- `--rip=false`: skip the per-config real-IP lookup. We never use that CSV column (instance IP comes from get_public_ip), and it cost one extra request per config.

Every config is still tested and still gets an up/down data point.

## CSV parsing hardening
`csv_to_dict` split lines on `,` by hand. xray-knife quotes fields per RFC 4180, so a failed config whose `reason` contained a comma shifted every later column, misreading `delay` and `status`. Now parsed with `csv.DictReader` by column name. Verified against a sample row with a comma in `reason`.

**Behaviour change:** `valid_configs` and the `/valid-configs` endpoint now expose named-key objects (`{"link":..,"status":..,"delay":..}`) instead of positional arrays. Consumers reading that endpoint by array index need updating.