### PR TITLE
Drop dead /valid-configs endpoint and quiet acme.sh logs

### DIFF
--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -442,9 +442,15 @@ class XrayConfig:
                         cmd_list = [acme_bin] + shlex.split(cmd_args)
                         result = exec_command(
                             cmd_list,
-                            env={"CF_Token": self.cf_api_token or ""},
+                            # DEBUG=0: our app runs with DEBUG=true, but acme.sh
+                            # reads DEBUG as a numeric log level and spams
+                            # "integer expected".
+                            env={"CF_Token": self.cf_api_token or "", "DEBUG": "0"},
                         )
-                        if result.returncode != 0:
+                        # acme.sh exits 2 when there is nothing to do (e.g. a
+                        # renewal that is not yet due); that is a no-op, not a
+                        # failure.
+                        if result.returncode not in (0, 2):
                             log.error(
                                 "acme.sh command failed",
                                 exit_code=result.returncode,

--- a/xray-config/run.py
+++ b/xray-config/run.py
@@ -42,10 +42,6 @@ class XrayService:
             clean = {k: v for k, v in config.xray_config.items() if v is not None}
             return json.dumps(clean, indent=4)
 
-        @self.app.route("/valid-configs")
-        def valid_configs_route():
-            return json.dumps(self.valid_configs, indent=4)
-
         @self.app.route("/subdomain")
         def export_certs():
             if not config.initialized or not config.direct_subdomain:
@@ -247,7 +243,9 @@ class XrayService:
                         "-d",
                         config.direct_subdomain,
                     ],
-                    env={"CF_Token": config.cf_api_token or ""},
+                    # DEBUG=0: our app runs with DEBUG=true, but acme.sh reads
+                    # DEBUG as a numeric log level and spams "integer expected".
+                    env={"CF_Token": config.cf_api_token or "", "DEBUG": "0"},
                 )
                 if result.returncode == 0:
                     # Cert files on the shared acme volume are now updated.


### PR DESCRIPTION
Two small cleanups surfaced while testing the xray-knife update.

## Remove /valid-configs
Nothing consumes this endpoint (checked the org: the only reference is its own definition; `agent.sh configs` and the metric pipeline both read `/metrics`). Dropping the dead route. `valid_configs` is still populated and used internally for metrics.

## Quiet acme.sh
Our app runs with `DEBUG=true`. `exec_command` merges the process env into every subprocess, so acme.sh inherited `DEBUG=true` and, since it treats DEBUG as a numeric log level, spammed `[: true: integer expected` on every run. Now passing `DEBUG=0` to the acme.sh calls.

Also, acme.sh exits 2 when a renewal is skipped (cert not due). The startup path logged that at error level ("acme.sh command failed"), which made a healthy skip look broken and would bury a real failure. Now exit 2 is treated as a no-op; only other non-zero codes log an error.