### PR TITLE
Bump xray-exporter to v0.6.4, default logs to info

### DIFF
--- a/xray-exporter/Dockerfile
+++ b/xray-exporter/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.22.4
 RUN apk add --no-cache ca-certificates wget && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then arch="amd64"; elif [ "$ARCH" = "aarch64" ]; then arch="arm64"; else echo "Unsupported architecture" && exit 1; fi && \
-    wget -O /xray-exporter https://github.com/compassvpn/xray-exporter/releases/download/v0.6.3/xray-exporter-linux-${arch} && \
+    wget -O /xray-exporter https://github.com/compassvpn/xray-exporter/releases/download/v0.6.4/xray-exporter-linux-${arch} && \
     chmod +x /xray-exporter && \
     apk del wget
 

--- a/xray-exporter/entrypoint.sh
+++ b/xray-exporter/entrypoint.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 # Follow the stack's DEBUG flag (read from the mounted env_file): debug when it's
-# on, warn otherwise. Normalized the same way as the nginx/xray entrypoints so a
-# stray capital or quotes still work.
+# on, info otherwise. info is the exporter's own default - warn hid the startup
+# and operational lines (server start, log-parser attach, geoip progress), so
+# operators saw nothing until an error. Normalized the same way as the
+# nginx/xray entrypoints so a stray capital or quotes still work.
 DEBUG=$(printf '%s' "${DEBUG:-false}" | tr -d "\"'" | tr '[:upper:]' '[:lower:]')
 if [ "$DEBUG" = "true" ]; then
     LOG_LEVEL=debug
 else
-    LOG_LEVEL=warn
+    LOG_LEVEL=info
 fi
 
 # --user-traffic-metrics: per-user byte counters (one series per user), on by choice.


### PR DESCRIPTION
Picks up xray-exporter v0.6.4.

**Version bump.** The real win is the memory-bounding fix: the log-based user-metric maps could grow unbounded when Prometheus stopped scraping (expiry lived in the scrape path, not the parse loop), and lifetime cumulative counts pruned by rank never decayed. v0.6.4 moves expiry into the parse loop and switches to windowed last-seen counts.

**Log level warn -> info (non-debug).** `warn` hid every startup and operational line (server start, log-parser attach, geoip progress), so on normal servers the exporter was silent until an error. `info` is the exporter's own default and repeat warnings are now throttled upstream, so the extra volume is bounded and the `log-small` size cap still holds. DEBUG=true still maps to `debug`.

Skipped the new `--log-format json` flag: our exporter stdout isn't shipped to an aggregator (json-file driver, read locally via docker logs), so JSON would only make it harder to read.

Not live-tested yet.