### PR TITLE
Drop unused node_cpu_seconds_total modes to cut cardinality

### DIFF
--- a/metric-forwarder/common.py
+++ b/metric-forwarder/common.py
@@ -118,6 +118,16 @@ prometheus.relabel "node_exporter" {{
     regex         = "node_network_receive_bytes_total|node_network_transmit_bytes_total|node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_filesystem_size_bytes|node_filesystem_avail_bytes"
     action        = "keep"
   }}
+  // node_cpu_seconds_total emits one series per (core, mode), but only the
+  // idle mode is graphed (CPU Usage = 100 - idle rate). Drop the 7 unused
+  // modes to cut this metric ~8x; the anchored __name__ match leaves idle
+  // and every other kept metric untouched.
+  rule {{
+    source_labels = ["__name__", "mode"]
+    separator     = ";"
+    regex         = "node_cpu_seconds_total;(user|nice|system|iowait|irq|softirq|steal|guest|guest_nice)"
+    action        = "drop"
+  }}
   rule {{
     source_labels = ["device"]
     regex         = "veth.*|io|br.*|lo|docker.*"


### PR DESCRIPTION
`node_cpu_seconds_total` is the highest-cardinality metric we ship: 512 series, ~33% of all active series. It carries one series per (core, mode) across 8 modes, but the dashboard only ever graphs the `idle` mode (`CPU Usage = 100 - idle rate`).

Add a relabel rule in the Alloy node-exporter pipeline to drop the 7 non-idle modes (`user, nice, system, iowait, irq, softirq, steal`, plus `guest/guest_nice` for safety) at ingest.

**Effect:** 512 -> 64 series for this metric, ~29% off the total series count. It drops from #1 cardinality source to a rounding error.

**Safety checked before shipping:**
- Only one panel (CPU Usage) reads this metric, and only `mode="idle"` — its input series set and computed value are unchanged.
- Every other dashboard: no reference. Zero recording rules, zero alert rules touch it.
- Anchored `__name__` match means idle and all other kept metrics are untouched.
- Rendered the generated `config.alloy` offline to confirm the f-string produces valid River (doubled braces are required since the config is Python-templated).