### PR TITLE
compose: raise per-netns TCP autotune caps, bound helper memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,14 @@ x-public-tuned: &public-tuned
     - net.core.somaxconn=8192
     - net.ipv4.tcp_max_syn_backlog=10240   # match the host value in agent.yml
     - net.ipv4.tcp_fin_timeout=25
+    # TCP autotuning maxima are per-netns and NOT inherited from the host
+    # (unlike net.core.rmem_max/wmem_max, which are global), so without these
+    # the client-facing sockets cap at the kernel defaults of ~6 MiB recv /
+    # 4 MiB send - about 160 Mbit/s per connection at 200 ms RTT.
+    - "net.ipv4.tcp_rmem=4096 262144 33554432"
+    - "net.ipv4.tcp_wmem=4096 262144 33554432"
+    - net.ipv4.tcp_mtu_probing=1            # clients behind broken PMTUD (common on filtered networks)
+    - net.ipv4.tcp_slow_start_after_idle=0  # don't reset cwnd on long-lived, bursty proxied connections
   logging:
     driver: "json-file"
     options:
@@ -156,6 +164,7 @@ services:
       context: ./xray-exporter
       dockerfile: Dockerfile
     restart: always
+    mem_limit: 256m   # helper, not in the data path: let the OOM killer take this before xray/nginx
     <<: [*log-small, *hardening]
     cap_drop:
       - ALL          # outbound scrape + GeoIP download + read-only log + :9550; no caps needed
@@ -183,6 +192,7 @@ services:
       context: ./metric-forwarder
       dockerfile: Dockerfile
     restart: always
+    mem_limit: 512m   # Alloy buffers and grows when the remote endpoint is unreachable; cap it
     network_mode: host
     <<: [*log-small, *hardening]
     cap_drop:
@@ -209,6 +219,7 @@ services:
   node-exporter:
     image: prom/node-exporter:v1.11.1
     restart: always
+    mem_limit: 128m   # helper, not in the data path
     network_mode: host
     <<: [*log-small, *hardening]
     cap_drop:


### PR DESCRIPTION
net.ipv4.tcp_rmem/tcp_wmem are per network namespace and start at the
kernel defaults regardless of the host's rmem_max/wmem_max, capping
client-facing connections at ~6 MiB recv / 4 MiB send (~160 Mbit/s at
200 ms RTT). Raise them to 32 MiB in the public-tuned services, enable
MTU probing for clients behind broken PMTUD, and keep cwnd across idle.

Cap memory on the three helper containers so under memory pressure the
OOM killer takes them instead of xray/nginx or the host.