### PR TITLE
Fix per-netns sysctls, prefer local resolver, trim comments

### DIFF
--- a/agent.yml
+++ b/agent.yml
@@ -1,34 +1,30 @@
 ---
-# One playbook for the whole CompassVPN host. Run it all (agent.sh does this),
-# or a single stage with tags, e.g. only redeploy:
+# Provisions and deploys the whole CompassVPN host. agent.sh runs it all; a
+# single stage runs via tags: prepare, docker, identifier, cron, deploy.
 #   uv run --frozen ansible-playbook agent.yml --tags deploy
-# Stages (tags): prepare, docker, identifier, cron, deploy.
 - name: Provision and deploy the CompassVPN host
   hosts: localhost
   connection: local
   become: true
-  gather_facts: false   # gathered explicitly, after we ensure python3 exists
+  gather_facts: false   # gathered explicitly, once python3 is guaranteed
 
   vars:
-    # Modules run on this same box (connection: local); pin the target interpreter
-    # so they don't fall back to a non-existent /usr/bin/python.
+    # Pin the interpreter so local modules don't look for /usr/bin/python.
     ansible_python_interpreter: /usr/bin/python3
     project_dir: "{{ playbook_dir }}"
 
-    # Operational knobs. agent.sh passes these in from env_file; defaults are
-    # "off" so a bare run never schedules cron jobs.
+    # agent.sh passes these in from env_file; empty means no cron job.
     auto_update: ""
     redeploy_interval: ""
 
-    # Upstream DNS resolvers, in priority order. Each is probed first and only the
-    # reachable ones are applied, so we never replace working DNS with dead entries.
+    # Priority order. Only the ones that answer a ping get applied, so we never
+    # swap working DNS for dead entries.
     dns_servers:
-      - "1.1.1.2"
       - "127.0.0.53"
+      - "1.1.1.2"
 
-    # Ports opened on the host firewall. The metrics ports (29100, 25000, 29550)
-    # are intentionally NOT here - they are bound to loopback and scraped over
-    # loopback by the host-network metric-forwarder, so no firewall rule is needed.
+    # Firewall openings. The metrics ports (29100, 25000, 29550) are deliberately
+    # absent: loopback-bound and scraped over loopback, so no rule is needed.
     required_ports:
       - 80
       - 8080
@@ -39,13 +35,12 @@
       - 8443
       - 8880
 
+    # Host netns only. Per-netns keys the proxy needs are set again in
+    # docker-compose.yml - a container does not inherit most of these.
     sysctl_conf_path: /etc/sysctl.d/99-compassvpn.conf
     sysctl_settings:
       fs.file-max: "67108864"
       net.core.default_qdisc: "fq"
-      net.core.optmem_max: "262144"
-      net.core.rmem_max: "33554432"
-      net.core.wmem_max: "33554432"
       net.ipv4.tcp_congestion_control: "bbr"
       net.ipv4.tcp_max_syn_backlog: "10240"
       net.ipv4.tcp_fin_timeout: "25"
@@ -63,9 +58,9 @@
       - debug.log
 
   tasks:
-    # ---- prerequisites (run under every tag) -------------------------------
-    # Minimal images can ship without python3 / python3-apt, which Ansible's setup
-    # and apt modules need. Bootstrap them with raw (needs no python on the target).
+    # ---- prerequisites (every tag) -----------------------------------------
+    # Minimal images can ship without python3 / python3-apt, which the setup and
+    # apt modules need. raw is the only module that works without them.
     - name: Ensure python3 and python3-apt are present
       ansible.builtin.raw: dpkg -s python3 python3-apt >/dev/null 2>&1 || (apt-get update && apt-get install -y python3 python3-apt)
       changed_when: false
@@ -75,8 +70,7 @@
       ansible.builtin.setup: {}
       tags: always
 
-    # Fail fast on unsupported hosts. ansible-core needs Python 3.9+ on the target,
-    # which rules out Ubuntu 20.04 (ships 3.8); Debian 11 (3.9) is the floor that works.
+    # ansible-core needs Python 3.9+, which rules out Ubuntu 20.04 (ships 3.8).
     - name: Check supported OS and version (Debian 11+, Ubuntu 22.04+)
       ansible.builtin.assert:
         that:
@@ -94,7 +88,7 @@
           {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }} is supported.
       tags: always
 
-    # ---- prepare: host packages, DNS, tuning, firewall, logs ---------------
+    # ---- prepare: packages, DNS, tuning, firewall, logs --------------------
     - name: Prepare the host
       tags: prepare
       block:
@@ -122,8 +116,8 @@
               - logrotate
             state: present
 
-        # Only a foreign process is a conflict - our own published ports show up as
-        # docker-proxy, so filter those out (lets re-runs on a live box pass).
+        # Our own ports show up as docker-proxy; filter those out so a re-run on
+        # a live box passes. Only a foreign process is a real conflict.
         - name: Fail early if a required port is held by a non-Docker process
           ansible.builtin.shell: |
             set -o pipefail
@@ -199,7 +193,7 @@
             sysctl_file: "{{ sysctl_conf_path }}"
             sysctl_set: true
             reload: false
-            ignoreerrors: true   # don't abort on a key the kernel won't take (e.g. conntrack on some kernels)
+            ignoreerrors: true   # some kernels reject a key (e.g. conntrack); don't abort
             state: present
           loop: "{{ sysctl_settings | dict2items }}"
           loop_control:
@@ -216,6 +210,7 @@
             name: ufw
             state: present
 
+        # Stops UFW reapplying its own sysctl file, which would undo ip_forward.
         - name: Point UFW at the system sysctl file
           ansible.builtin.replace:
             path: /etc/default/ufw
@@ -252,7 +247,7 @@
                 else ((configured_ssh_port.stdout | default('') | trim) or '22')
               }}
 
-        # Allow SSH BEFORE enabling so the deploy connection is never cut off.
+        # Before enabling UFW, or the deploy cuts off its own connection.
         - name: Allow the SSH port in UFW
           community.general.ufw:
             rule: allow
@@ -363,15 +358,11 @@
           when: docker_check.rc != 0
 
     # ---- docker network: non-conflicting address pools ---------------------
-    # Docker allocates bridge subnets from 172.16.0.0/12, which collides with
-    # VNets in that block (common on Azure) and wedges networking. Its built-in
-    # avoidance only covers subnets it auto-picks, not ones it's handed, so pin
-    # both out of that range into a quiet 10.x block: bip moves docker0,
-    # default-address-pools moves the compose network. Docker still skips any
-    # pool range already in use on the host, as a backstop. The trailing v6 ULA
-    # pool feeds the compose network's enable_ipv6 (internal-only, collision-safe
-    # by design), so both families source from here. Also tagged 'deploy' so a
-    # deploy-only run configures the daemon before it starts any containers.
+    # Docker's default 172.16.0.0/12 collides with VNets in that block (common on
+    # Azure) and wedges networking, so move docker0 (bip) and the compose network
+    # (pools) into a quiet 10.x range. The v6 ULA pool feeds enable_ipv6 in
+    # docker-compose.yml. Tagged 'deploy' too, so a deploy-only run configures the
+    # daemon before starting containers.
     - name: Point Docker at non-conflicting address pools
       tags: [docker, deploy]
       block:
@@ -398,8 +389,7 @@
           when: docker_daemon.changed
 
     # ---- identifier: a stable per-node label, generated once ---------------
-    # Also tagged 'deploy' so a deploy-only run can't start containers without an
-    # IDENTIFIER (the services hard-fail if it's missing). It's a no-op once set.
+    # Tagged 'deploy' too: the services hard-fail without IDENTIFIER. No-op once set.
     - name: Ensure a unique node identifier
       tags: [identifier, deploy]
       block:

--- a/agent.yml
+++ b/agent.yml
@@ -1,15 +1,13 @@
 ---
-# Provisions and deploys the whole CompassVPN host. agent.sh runs it all; a
-# single stage runs via tags: prepare, docker, identifier, cron, deploy.
+# agent.sh runs the whole thing. A single stage runs via tags:
 #   uv run --frozen ansible-playbook agent.yml --tags deploy
 - name: Provision and deploy the CompassVPN host
   hosts: localhost
   connection: local
   become: true
-  gather_facts: false   # gathered explicitly, once python3 is guaranteed
+  gather_facts: false   # gathered later, once python3 is guaranteed
 
   vars:
-    # Pin the interpreter so local modules don't look for /usr/bin/python.
     ansible_python_interpreter: /usr/bin/python3
     project_dir: "{{ playbook_dir }}"
 
@@ -17,14 +15,14 @@
     auto_update: ""
     redeploy_interval: ""
 
-    # Priority order. Only the ones that answer a ping get applied, so we never
-    # swap working DNS for dead entries.
+    # Priority order, and unreachable ones are dropped before we write
+    # resolv.conf, so we never swap working DNS for dead entries.
     dns_servers:
       - "127.0.0.53"
       - "1.1.1.2"
 
-    # Firewall openings. The metrics ports (29100, 25000, 29550) are deliberately
-    # absent: loopback-bound and scraped over loopback, so no rule is needed.
+    # The metrics ports (29100, 25000, 29550) belong nowhere near this list -
+    # they're loopback-only and scraped over loopback.
     required_ports:
       - 80
       - 8080
@@ -35,8 +33,8 @@
       - 8443
       - 8880
 
-    # Host netns only. Per-netns keys the proxy needs are set again in
-    # docker-compose.yml - a container does not inherit most of these.
+    # Host netns only. Containers don't inherit most of these, so the keys the
+    # proxy needs are set again in docker-compose.yml.
     sysctl_conf_path: /etc/sysctl.d/99-compassvpn.conf
     sysctl_settings:
       fs.file-max: "67108864"
@@ -59,8 +57,8 @@
 
   tasks:
     # ---- prerequisites (every tag) -----------------------------------------
-    # Minimal images can ship without python3 / python3-apt, which the setup and
-    # apt modules need. raw is the only module that works without them.
+    # Minimal images ship without python3 / python3-apt, and raw is the only
+    # module that works before they're there.
     - name: Ensure python3 and python3-apt are present
       ansible.builtin.raw: dpkg -s python3 python3-apt >/dev/null 2>&1 || (apt-get update && apt-get install -y python3 python3-apt)
       changed_when: false
@@ -70,7 +68,7 @@
       ansible.builtin.setup: {}
       tags: always
 
-    # ansible-core needs Python 3.9+, which rules out Ubuntu 20.04 (ships 3.8).
+    # The floor is ansible-core needing Python 3.9+, which rules out Ubuntu 20.04.
     - name: Check supported OS and version (Debian 11+, Ubuntu 22.04+)
       ansible.builtin.assert:
         that:
@@ -116,8 +114,8 @@
               - logrotate
             state: present
 
-        # Our own ports show up as docker-proxy; filter those out so a re-run on
-        # a live box passes. Only a foreign process is a real conflict.
+        # Our own ports show up as docker-proxy, so filter those out or a re-run
+        # on a live box fails on itself.
         - name: Fail early if a required port is held by a non-Docker process
           ansible.builtin.shell: |
             set -o pipefail
@@ -210,7 +208,8 @@
             name: ufw
             state: present
 
-        # Stops UFW reapplying its own sysctl file, which would undo ip_forward.
+        # Otherwise UFW reapplies its own sysctl file and undoes ip_forward,
+        # which breaks Docker networking.
         - name: Point UFW at the system sysctl file
           ansible.builtin.replace:
             path: /etc/default/ufw
@@ -247,7 +246,7 @@
                 else ((configured_ssh_port.stdout | default('') | trim) or '22')
               }}
 
-        # Before enabling UFW, or the deploy cuts off its own connection.
+        # Must come before UFW is enabled, or the deploy locks itself out.
         - name: Allow the SSH port in UFW
           community.general.ufw:
             rule: allow
@@ -359,12 +358,11 @@
 
     # ---- docker network: non-conflicting address pools ---------------------
     # Docker's default 172.16.0.0/12 collides with VNets in that block (common on
-    # Azure) and wedges networking, so move docker0 (bip) and the compose network
-    # (pools) into a quiet 10.x range. The v6 ULA pool feeds enable_ipv6 in
-    # docker-compose.yml. Tagged 'deploy' too, so a deploy-only run configures the
-    # daemon before starting containers.
+    # Azure) and wedges networking, so bip moves docker0 and the pools move the
+    # compose network, both into a quiet 10.x range. The v6 pool is what
+    # enable_ipv6 in docker-compose.yml draws from.
     - name: Point Docker at non-conflicting address pools
-      tags: [docker, deploy]
+      tags: [docker, deploy]   # 'deploy' too, so the daemon is fixed before containers start
       block:
         - name: Write /etc/docker/daemon.json
           ansible.builtin.copy:
@@ -389,7 +387,7 @@
           when: docker_daemon.changed
 
     # ---- identifier: a stable per-node label, generated once ---------------
-    # Tagged 'deploy' too: the services hard-fail without IDENTIFIER. No-op once set.
+    # Tagged 'deploy' as well, since the services hard-fail without IDENTIFIER.
     - name: Ensure a unique node identifier
       tags: [identifier, deploy]
       block:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,45 +1,33 @@
-# CompassVPN stack. Six containers working together:
-#   xray-config  - builds the Xray config and gets/renews TLS certs (internal only)
-#   xray         - the actual proxy; handles all the public VPN traffic
-#   nginx        - public TLS front + a decoy site for anything that isn't real traffic
-#   xray-exporter / metric-forwarder / node-exporter - the metrics pipeline
-#
-# The anchors below keep the repeated logging / tuning / hardening bits in one
-# place so we set them once and reuse them.
+# CompassVPN stack: xray-config (config + TLS certs), xray (the proxy),
+# nginx (TLS front + decoy site), and the metrics trio.
 
-# Tuning for the busy, public-facing services (xray, nginx): raise the open-file
-# limit, tune the TCP stack a bit, and keep a little more log history.
+# Shared tuning for the public-facing services (xray, nginx).
 x-public-tuned: &public-tuned
   ulimits:
     nofile:
-      # Way above what normal load needs: xray's httpupgrade listener dies
-      # for good if accept() ever hits EMFILE (leaked half-open handshakes
-      # fill the fd table), so keep that ceiling far away.
+      # xray's httpupgrade listener wedges for good if accept() hits EMFILE, so
+      # keep the ceiling far out of reach. nginx lowers itself to
+      # worker_rlimit_nofile anyway. 1048576 is the fs.nr_open default ceiling.
       soft: 1048576
       hard: 1048576
-  # These sysctls are per-network-namespace, so they apply only inside the
-  # container - intentionally separate from the host values in agent.yml
-  # (don't delete them thinking they're duplicates).
+  # Per-netns keys. A container gets fresh kernel defaults for these, so the
+  # matching lines in agent.yml do not cover it - keep both in sync.
   sysctls:
-    - net.core.somaxconn=8192
-    - net.ipv4.tcp_max_syn_backlog=10240   # match the host value in agent.yml
+    - net.core.somaxconn=8192               # xray only; nginx needs listen backlog=
+    - net.core.optmem_max=262144
+    - net.ipv4.tcp_max_syn_backlog=10240
     - net.ipv4.tcp_fin_timeout=25
-    # TCP autotuning maxima are per-netns and NOT inherited from the host
-    # (unlike net.core.rmem_max/wmem_max, which are global), so without these
-    # the client-facing sockets cap at the kernel defaults of ~6 MiB recv /
-    # 4 MiB send - about 160 Mbit/s per connection at 200 ms RTT.
-    - "net.ipv4.tcp_rmem=4096 262144 33554432"
-    - "net.ipv4.tcp_wmem=4096 262144 33554432"
-    - net.ipv4.tcp_mtu_probing=1            # clients behind broken PMTUD (common on filtered networks)
-    - net.ipv4.tcp_slow_start_after_idle=0  # don't reset cwnd on long-lived, bursty proxied connections
+    - net.ipv4.tcp_congestion_control=bbr   # inherited from the host, pinned so it can't drift
+    - "net.ipv4.tcp_rmem=4096 262144 33554432"   # autotune ceiling; default is ~6 MiB
+    - "net.ipv4.tcp_wmem=4096 262144 33554432"   # autotune ceiling; default is ~4 MiB
+    - net.ipv4.tcp_mtu_probing=1            # clients behind broken PMTUD
+    - net.ipv4.tcp_slow_start_after_idle=0  # long-lived bursty connections
   logging:
     driver: "json-file"
     options:
       max-size: "10m"
       max-file: "3"
 
-# The quiet helper services don't need that tuning - just keep their logs small.
-# (Logging only, no perf settings - hence the name.)
 x-log-small: &log-small
   logging:
     driver: "json-file"
@@ -47,18 +35,14 @@ x-log-small: &log-small
       max-size: "5m"
       max-file: "1"
 
-# Baseline hardening shared by every service: forbid a process from gaining new
-# privileges (e.g. via a setuid binary). Capabilities are dropped per-service.
 x-hardening: &hardening
   security_opt:
     - "no-new-privileges:true"
 
 services:
 
-  # Brain of the stack: generates the Xray config, fetches/renews TLS certs via
-  # acme.sh + the Cloudflare API, and runs the config self-tests. Talks to the
-  # other containers over the internal network; its only published port is the
-  # metrics endpoint, and that is bound to the host's loopback.
+  # Generates the Xray config, renews TLS certs (acme.sh + Cloudflare API),
+  # runs the config self-tests.
   xray-config:
     build:
       context: ./xray-config
@@ -66,7 +50,7 @@ services:
     restart: always
     <<: [*log-small, *hardening]
     cap_drop:
-      - ALL          # key crypto + outbound HTTPS + Flask on :5000; no caps needed
+      - ALL
     env_file:
       - env_file
     environment:
@@ -74,20 +58,17 @@ services:
       - PYTHONPATH=/
     volumes:
       - "/etc/machine-id:/host/etc/machine-id"   # stable host id, used as a metric label
-      - "acme:/root/.acme.sh/"                    # cert store - this one writes it, xray/nginx read it
+      - "acme:/root/.acme.sh/"                   # cert store; xray and nginx read it
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/root/env_file:ro"
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
     ports:
-      # Metrics for the host-network metric-forwarder; loopback only, not
-      # reachable from outside. Host port 25000 rather than 5000: 5000 is a
-      # common default (Flask, docker registry), and ports below 32768 sit
-      # outside the kernel's ephemeral range, so an outbound connection can
-      # never be holding the port when the proxy tries to bind it.
+      # Metrics for the metric-forwarder, loopback only. 25000 not 5000: 5000 is
+      # a common default and sits inside no ephemeral range, so nothing can be
+      # squatting the port when we bind it.
       - "127.0.0.1:25000:5000"
 
-  # The actual proxy - this is what clients connect to and where all the VPN
-  # traffic flows. In "warp" mode it also brings up a WireGuard tunnel for egress.
+  # The proxy. In warp mode it also brings up a WireGuard tunnel for egress.
   xray:
     build:
       context: ./xray
@@ -97,13 +78,13 @@ services:
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
       - "./shared_lib:/shared_lib:ro"
       - "./env_file:/env_file:ro"
-      - "acme:/root/.acme.sh/:ro"               # read-only: only xray-config renews certs
+      - "acme:/root/.acme.sh/:ro"               # only xray-config renews certs
     cap_drop:
       - ALL
     cap_add:
-      - NET_ADMIN          # wg-quick creates the WireGuard interface (warp mode)
-      - NET_RAW            # busybox ping liveness check in wg_monit
-      - NET_BIND_SERVICE   # bind :443 (harmless now; needed if xray ever runs non-root)
+      - NET_ADMIN          # wg-quick interface (warp mode)
+      - NET_RAW            # busybox ping in wg_monit
+      - NET_BIND_SERVICE   # bind :443 if xray ever runs non-root
     restart: always
     env_file:
       - env_file
@@ -111,16 +92,15 @@ services:
       - TZ=UTC
       - PYTHONPATH=/
     depends_on:
-      - xray-config        # needs the generated config before it can start
-    ports:                 # public entry points (both TCP and UDP)
+      - xray-config
+    ports:
       - "443:443/tcp"
       - "443:443/udp"
-      - "2083:2083/tcp"    # vless-tcp-reality-direct (raw TCP, no nginx in front)
-      - "2087:2087/tcp"    # vless-xhttp-reality-direct (REALITY over XHTTP, no nginx)
+      - "2083:2083/tcp"    # vless-tcp-reality-direct, no nginx in front
+      - "2087:2087/tcp"    # vless-xhttp-reality-direct, no nginx in front
 
-  # Public TLS front + camouflage. Real proxy paths get forwarded to xray;
-  # everything else falls through to a decoy website. Builds its config from
-  # what xray-config serves at startup.
+  # TLS front + camouflage: proxy paths go to xray, everything else to a decoy
+  # site. Builds its config from what xray-config serves at startup.
   nginx:
     build:
       context: ./nginx
@@ -129,10 +109,10 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      - SETUID         # master spawns workers as the 'nginx' user
+      - SETUID         # spawn workers as the 'nginx' user
       - SETGID
-      - CHOWN          # chown worker cache/temp dirs
-      - DAC_OVERRIDE   # master opens logs/pid/cache before dropping privileges
+      - CHOWN          # worker cache/temp dirs
+      - DAC_OVERRIDE   # open logs/pid/cache before dropping privileges
       - KILL           # 'nginx -s reload' on cert renewal
     volumes:
       - "acme:/root/.acme.sh/"
@@ -142,8 +122,8 @@ services:
     restart: always
     env_file:
       - env_file
-    ports:                 # public entry points (both TCP and UDP)
-      - "8080:8080/tcp"    # vless-hu-* (non-TLS httpupgrade, VLESS encryption)
+    ports:
+      - "8080:8080/tcp"    # vless-hu-*, non-TLS httpupgrade
       - "8080:8080/udp"
       - "8880:8880/tcp"
       - "8880:8880/udp"
@@ -157,46 +137,43 @@ services:
     depends_on:
       - xray
 
-  # Reads Xray's access log and exposes it as Prometheus metrics on :9550. Also
-  # pulls the GeoIP dbs from GitHub on startup (cached in the xray_geoip volume).
+  # Turns Xray's access log into Prometheus metrics. Pulls the GeoIP dbs on
+  # first start.
   xray-exporter:
     build:
       context: ./xray-exporter
       dockerfile: Dockerfile
     restart: always
-    mem_limit: 256m   # helper, not in the data path: let the OOM killer take this before xray/nginx
+    mem_limit: 256m   # helper: let the OOM killer take this before xray/nginx
     <<: [*log-small, *hardening]
     cap_drop:
-      - ALL          # outbound scrape + GeoIP download + read-only log + :9550; no caps needed
+      - ALL
     depends_on:
       - xray
     volumes:
       - /var/log/compassvpn:/var/log/compassvpn:ro
-      - "xray_geoip:/geoip"   # cache the downloaded GeoIP dbs
+      - "xray_geoip:/geoip"
       - "./shared_lib:/shared_lib:ro"
     ports:
-      - "127.0.0.1:29550:9550"   # metrics for the host-network metric-forwarder; loopback only (29550: see the port note on xray-config)
+      - "127.0.0.1:29550:9550"   # loopback only; 29550 not 9550, see xray-config
     env_file:
-      - env_file          # entrypoint reads DEBUG from here to pick its log level
+      - env_file          # entrypoint reads DEBUG for its log level
     environment:
       - PYTHONPATH=/
 
-  # Runs Grafana Alloy: scrapes the local metrics (node-exporter, xray-config,
-  # xray-exporter) and ships them off to the remote Grafana endpoint. Shares the
-  # host network namespace so every scrape target is 127.0.0.1: loopback behaves
-  # the same on every host, while container-to-host traffic crosses the host
-  # INPUT chain and depends on the firewall rules and Docker's bridge subnets,
-  # both of which vary per host.
+  # Grafana Alloy: scrapes the local metrics and ships them to Grafana. Host
+  # netns so every target is 127.0.0.1 - same on every host, unlike
+  # container-to-host traffic, which depends on firewall and bridge subnets.
   metric-forwarder:
     build:
       context: ./metric-forwarder
       dockerfile: Dockerfile
     restart: always
-    mem_limit: 512m   # Alloy buffers and grows when the remote endpoint is unreachable; cap it
+    mem_limit: 512m   # Alloy buffers when the remote endpoint is unreachable
     network_mode: host
     <<: [*log-small, *hardening]
     cap_drop:
-      - ALL          # pure outbound Alloy forwarder; no caps needed
+      - ALL
     env_file:
       - env_file
     environment:
@@ -209,23 +186,18 @@ services:
       - xray-config
       - node-exporter
 
-  # Standard host metrics (CPU, memory, disk, network). Must share the host
-  # network namespace: /proc/net is a symlink to /proc/self/net, so the netdev
-  # collector reports whatever netns it runs in - from an isolated netns it
-  # would only see the container's own veth, not the host NICs. It binds to
-  # loopback only: the metric-forwarder shares the host netns and scrapes it
-  # over 127.0.0.1, and nothing else - containers, VPN clients proxying to the
-  # server's own IP, or the internet - can reach loopback at all.
+  # Host metrics. Needs the host netns or the netdev collector sees only the
+  # container's veth instead of the host NICs.
   node-exporter:
     image: prom/node-exporter:v1.11.1
     restart: always
-    mem_limit: 128m   # helper, not in the data path
+    mem_limit: 128m
     network_mode: host
     <<: [*log-small, *hardening]
     cap_drop:
-      - ALL          # enabled collectors are pure procfs/sysfs readers
-    read_only: true  # writes nothing; all mounts are read-only
-    user: "65534:65534"   # 'nobody' - this image already runs as nobody by default
+      - ALL
+    read_only: true
+    user: "65534:65534"   # nobody
     volumes:
       - "/proc:/host/proc:ro"
       - "/sys:/host/sys:ro"
@@ -236,8 +208,8 @@ services:
       - "--log.level=warn"
       - "--path.procfs=/host/proc"
       - "--path.sysfs=/host/sys"
-      - "--path.rootfs=/rootfs" # statfs the host filesystems via the mounted root, not the container's
-      # only collect what we actually graph - everything else stays off
+      - "--path.rootfs=/rootfs"
+      # only collect what we graph
       - '--collector.disable-defaults'
       - '--collector.uname'
       - '--collector.cpu'
@@ -247,22 +219,15 @@ services:
       - '--collector.time'
       - '--collector.stat'
       - '--collector.pressure'
-      - "--web.listen-address=127.0.0.1:29100" # loopback only; 29100 not 9100 so an apt-installed node-exporter can't collide
+      - "--web.listen-address=127.0.0.1:29100" # loopback only; 29100 avoids a clash with an apt-installed node-exporter
 
-# Shared cert store: xray-config writes here (acme.sh), xray and nginx read from it.
 volumes:
   acme:
-  # GeoIP dbs the xray-exporter downloads on startup - kept so we don't re-fetch
-  # them from GitHub on every restart.
   xray_geoip:
 
-# Give the default bridge IPv6 so the direct inbounds (reality on 2083/2087 and
-# 443) see real client v6 addresses via ip6tables DNAT, instead of collapsing
-# them to the bridge gateway through docker-proxy.
-#
-# Neither subnet is pinned here; both come from the daemon's address pools (set
-# in agent.yml): a host-local 10.x block for v4 that stays clear of the host's
-# own networks, and an internal-only ULA for v6. One source of truth.
+# IPv6 on the bridge so the direct inbounds see real client v6 addresses via
+# ip6tables DNAT instead of the bridge gateway. Subnets come from the daemon
+# address pools in agent.yml, not pinned here.
 networks:
   default:
     enable_ipv6: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,24 @@
-# CompassVPN stack: xray-config (config + TLS certs), xray (the proxy),
-# nginx (TLS front + decoy site), and the metrics trio.
-
-# Shared tuning for the public-facing services (xray, nginx).
+# Shared tuning for the two services that face the public internet.
 x-public-tuned: &public-tuned
   ulimits:
     nofile:
-      # xray's httpupgrade listener wedges for good if accept() hits EMFILE, so
-      # keep the ceiling far out of reach. nginx lowers itself to
-      # worker_rlimit_nofile anyway. 1048576 is the fs.nr_open default ceiling.
+      # xray's httpupgrade listener wedges for good if accept() ever hits
+      # EMFILE, so keep the ceiling far out of reach.
       soft: 1048576
       hard: 1048576
-  # Per-netns keys. A container gets fresh kernel defaults for these, so the
-  # matching lines in agent.yml do not cover it - keep both in sync.
+  # These are per-netns: a container starts from kernel defaults, so the same
+  # keys in agent.yml don't reach it. Change both or neither.
   sysctls:
     - net.core.somaxconn=8192               # xray only; nginx needs listen backlog=
     - net.core.optmem_max=262144
     - net.ipv4.tcp_max_syn_backlog=10240
     - net.ipv4.tcp_fin_timeout=25
-    - net.ipv4.tcp_congestion_control=bbr   # inherited from the host, pinned so it can't drift
-    - "net.ipv4.tcp_rmem=4096 262144 33554432"   # autotune ceiling; default is ~6 MiB
-    - "net.ipv4.tcp_wmem=4096 262144 33554432"   # autotune ceiling; default is ~4 MiB
+    - net.ipv4.tcp_congestion_control=bbr   # pinned; otherwise inherited at container creation
+    # Autotune ceilings. Without these, sockets stop at ~6 MiB recv / 4 MiB send.
+    - "net.ipv4.tcp_rmem=4096 262144 33554432"
+    - "net.ipv4.tcp_wmem=4096 262144 33554432"
     - net.ipv4.tcp_mtu_probing=1            # clients behind broken PMTUD
-    - net.ipv4.tcp_slow_start_after_idle=0  # long-lived bursty connections
+    - net.ipv4.tcp_slow_start_after_idle=0  # long-lived, bursty connections
   logging:
     driver: "json-file"
     options:
@@ -41,8 +38,7 @@ x-hardening: &hardening
 
 services:
 
-  # Generates the Xray config, renews TLS certs (acme.sh + Cloudflare API),
-  # runs the config self-tests.
+  # Generates the Xray config and renews the TLS certs (acme.sh + Cloudflare).
   xray-config:
     build:
       context: ./xray-config
@@ -63,9 +59,8 @@ services:
       - "./env_file:/root/env_file:ro"
       - "/var/log/compassvpn:/var/log/compassvpn:rw"
     ports:
-      # Metrics for the metric-forwarder, loopback only. 25000 not 5000: 5000 is
-      # a common default and sits inside no ephemeral range, so nothing can be
-      # squatting the port when we bind it.
+      # Metrics for the forwarder. Loopback only, and 25000 rather than 5000 so
+      # nothing else on the box can be holding the port when we bind it.
       - "127.0.0.1:25000:5000"
 
   # The proxy. In warp mode it also brings up a WireGuard tunnel for egress.
@@ -99,8 +94,8 @@ services:
       - "2083:2083/tcp"    # vless-tcp-reality-direct, no nginx in front
       - "2087:2087/tcp"    # vless-xhttp-reality-direct, no nginx in front
 
-  # TLS front + camouflage: proxy paths go to xray, everything else to a decoy
-  # site. Builds its config from what xray-config serves at startup.
+  # TLS front and camouflage: proxy paths go to xray, everything else to a
+  # decoy site.
   nginx:
     build:
       context: ./nginx
@@ -137,14 +132,13 @@ services:
     depends_on:
       - xray
 
-  # Turns Xray's access log into Prometheus metrics. Pulls the GeoIP dbs on
-  # first start.
+  # Turns Xray's access log into Prometheus metrics.
   xray-exporter:
     build:
       context: ./xray-exporter
       dockerfile: Dockerfile
     restart: always
-    mem_limit: 256m   # helper: let the OOM killer take this before xray/nginx
+    mem_limit: 256m   # helper: let the OOM killer take this before xray or nginx
     <<: [*log-small, *hardening]
     cap_drop:
       - ALL
@@ -152,24 +146,24 @@ services:
       - xray
     volumes:
       - /var/log/compassvpn:/var/log/compassvpn:ro
-      - "xray_geoip:/geoip"
+      - "xray_geoip:/geoip"   # so we don't refetch the GeoIP dbs on every restart
       - "./shared_lib:/shared_lib:ro"
     ports:
-      - "127.0.0.1:29550:9550"   # loopback only; 29550 not 9550, see xray-config
+      - "127.0.0.1:29550:9550"   # loopback only, offset port; same reason as xray-config
     env_file:
-      - env_file          # entrypoint reads DEBUG for its log level
+      - env_file
     environment:
       - PYTHONPATH=/
 
-  # Grafana Alloy: scrapes the local metrics and ships them to Grafana. Host
-  # netns so every target is 127.0.0.1 - same on every host, unlike
-  # container-to-host traffic, which depends on firewall and bridge subnets.
+  # Grafana Alloy: scrapes the local metrics and ships them out. Host netns so
+  # every target is 127.0.0.1, which behaves the same everywhere;
+  # container-to-host traffic would depend on the firewall and bridge subnets.
   metric-forwarder:
     build:
       context: ./metric-forwarder
       dockerfile: Dockerfile
     restart: always
-    mem_limit: 512m   # Alloy buffers when the remote endpoint is unreachable
+    mem_limit: 512m   # Alloy buffers when it can't reach the remote endpoint
     network_mode: host
     <<: [*log-small, *hardening]
     cap_drop:
@@ -186,8 +180,8 @@ services:
       - xray-config
       - node-exporter
 
-  # Host metrics. Needs the host netns or the netdev collector sees only the
-  # container's veth instead of the host NICs.
+  # Host metrics. Needs the host netns, or the netdev collector reports the
+  # container's own veth instead of the real NICs.
   node-exporter:
     image: prom/node-exporter:v1.11.1
     restart: always
@@ -197,7 +191,7 @@ services:
     cap_drop:
       - ALL
     read_only: true
-    user: "65534:65534"   # nobody
+    user: "65534:65534"
     volumes:
       - "/proc:/host/proc:ro"
       - "/sys:/host/sys:ro"
@@ -209,7 +203,7 @@ services:
       - "--path.procfs=/host/proc"
       - "--path.sysfs=/host/sys"
       - "--path.rootfs=/rootfs"
-      # only collect what we graph
+      # only what we actually graph
       - '--collector.disable-defaults'
       - '--collector.uname'
       - '--collector.cpu'
@@ -219,15 +213,14 @@ services:
       - '--collector.time'
       - '--collector.stat'
       - '--collector.pressure'
-      - "--web.listen-address=127.0.0.1:29100" # loopback only; 29100 avoids a clash with an apt-installed node-exporter
+      - "--web.listen-address=127.0.0.1:29100"   # loopback only; offset so an apt-installed node-exporter can't collide
 
 volumes:
   acme:
   xray_geoip:
 
-# IPv6 on the bridge so the direct inbounds see real client v6 addresses via
-# ip6tables DNAT instead of the bridge gateway. Subnets come from the daemon
-# address pools in agent.yml, not pinned here.
+# IPv6 on the bridge so the direct inbounds see real client v6 addresses
+# instead of the gateway. Subnets come from the daemon pools in agent.yml.
 networks:
   default:
     enable_ipv6: true


### PR DESCRIPTION
Some of the host tuning in `agent.yml` never actually reached the containers, where the traffic is.

**`net.core.optmem_max`** is per-netns and every new netns gets a fresh 128 KiB ([net_namespace.c](https://github.com/torvalds/linux/blob/v6.12/net/core/net_namespace.c#L318)), never the host value. Moved to the compose anchor.

**`net.ipv4.tcp_congestion_control=bbr`** does reach containers, since `tcp_sk_init` copies it from `init_net` - but only at netns creation. On OpenVZ the whole sysctl block is skipped, and re-running the playbook against an already-running stack leaves existing containers on whatever was set when they started. Either way the proxy silently falls back to cubic. Pinned it in compose.

**`net.core.rmem_max` / `wmem_max`** dropped. They're read-only inside a netns (global storage, exposed read-only since 6.10) and on the host TCP autotuning ignores them - only an explicit `setsockopt(SO_RCVBUF)` honours them, which nothing here does. `tcp_rmem`/`tcp_wmem` in compose already do the real work.

**`dns_servers`** now lists `127.0.0.53` before `1.1.1.2`, so a host running the systemd stub resolver keeps it instead of being pushed onto an upstream. Unreachable entries are still dropped by the existing ping probe, so a host without the stub falls through to `1.1.1.2` as before.

Also fixed the `tcp_rmem` comment: it said the values aren't inherited from the host. They are, since 4.15. They still need setting because `agent.yml` never sets the host ones.

Then trimmed the comments in both files: 64 -> 27 in compose, 38 -> 31 in `agent.yml`, one style across both.

Left alone: nginx ignores `somaxconn` without `backlog=` on its listen directives and lowers itself to `worker_rlimit_nofile 65535`, so those two anchor settings only reach xray. Noted in comments rather than changed, since nginx isn't the service with the EMFILE wedge.

Not live-tested yet. The three removed keys stay in `/etc/sysctl.d/99-compassvpn.conf` on hosts already provisioned, since the sysctl module only adds lines.