### PR TITLE
Add warp-selective outbound mode

### DIFF
--- a/env_file.example
+++ b/env_file.example
@@ -19,8 +19,14 @@ CF_API_TOKEN=
 CF_ZONE_ID=
 CF_CLEAN_IP_DOMAIN=
 
-# Egress mode: "direct", or "warp" to route out through a WireGuard/WARP tunnel.
+# Egress mode: "direct", "warp" to route everything out through a WireGuard/WARP
+# tunnel, or "warp-selective" to send only WARP_DOMAINS through it.
 XRAY_OUTBOUND=direct
+
+# Domains routed through WARP when XRAY_OUTBOUND=warp-selective (comma-separated,
+# geosite: prefixes work). Useful for services that reject data-center IPs.
+# Empty falls back to direct.
+WARP_DOMAINS=
 
 # Inbounds to enable (comma-separated). Append :<count> for replicas via path-based
 # routing, e.g. vless-hu-tls-cdn:3

--- a/env_file.example
+++ b/env_file.example
@@ -19,12 +19,14 @@ CF_API_TOKEN=
 CF_ZONE_ID=
 CF_CLEAN_IP_DOMAIN=
 
-# Egress mode: "direct", "warp" to route everything out through a WireGuard/WARP
-# tunnel, or "warp-selective" to send only WARP_DOMAINS through it.
+# Egress mode: "direct", "warp" or "warp-selective". With "warp" all outbound
+# traffic goes through Cloudflare WARP, one WARP per inbound. With
+# "warp-selective" only what you list in WARP_DOMAINS goes through WARP, the
+# rest goes direct.
 XRAY_OUTBOUND=direct
 
-# Domains routed through WARP when XRAY_OUTBOUND=warp-selective (comma-separated,
-# geosite: prefixes work). Useful for services that reject data-center IPs.
+# Only used when XRAY_OUTBOUND=warp-selective. The domains and services you want
+# to send through WARP, comma-separated, e.g. geosite:spotify,gemini.google.com
 # Empty falls back to direct.
 WARP_DOMAINS=
 

--- a/xray-config/config.py
+++ b/xray-config/config.py
@@ -768,7 +768,9 @@ class XrayConfig:
                     hypothesisId="CFG",
                 )
 
-        # WARP configuration
+        # WARP configuration. "warp" gives every inbound its own tunnel;
+        # "warp-selective" keeps one shared tunnel and only sends WARP_DOMAINS
+        # through it, everything else stays on the direct outbound.
         self.warps_ready = False
         self.wg_configs = {}
         warp_active = False
@@ -776,10 +778,26 @@ class XrayConfig:
             ib for ib in self.configured_inbounds
             if "inbound" in ib and "tag" in ib["inbound"]
         ]
-        if self.env_config.get("XRAY_OUTBOUND") == "warp":
+        outbound_mode = self.env_config.get("XRAY_OUTBOUND", "direct")
+        selective = outbound_mode == "warp-selective"
+        warp_domains = [
+            d.strip()
+            for d in self.env_config.get("WARP_DOMAINS", "").split(",")
+            if d.strip()
+        ]
+        if selective and not warp_domains:
+            log.warning(
+                "XRAY_OUTBOUND is warp-selective but WARP_DOMAINS is empty; "
+                "using direct outbound",
+                hypothesisId="WARP",
+            )
+            selective = False
+            outbound_mode = "direct"
+
+        if outbound_mode in ("warp", "warp-selective"):
             try:
                 self.warps = []
-                for i in range(len(active_inbounds)):
+                for i in range(1 if selective else len(active_inbounds)):
                     if i > 0:
                         sleep(2)
                     self.warps.append(register_warp())
@@ -791,6 +809,12 @@ class XrayConfig:
                     hypothesisId="WARP",
                     error=str(e),
                 )
+
+        direct_outbound = {
+            "tag": "direct",
+            "protocol": "freedom",
+            "settings": {"domainStrategy": "UseIPv4"},
+        }
 
         if warp_active:
             for i, warp in enumerate(self.warps):
@@ -810,45 +834,51 @@ AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = engage.cloudflareclient.com:2408
 """
 
-            self.xray_config["routing"]["domainStrategy"] = "IPOnDemand"
+            if selective:
+                # Appended, so the block rules above still win over WARP_DOMAINS.
+                if active_inbounds:
+                    self.xray_config["routing"]["rules"].append(
+                        {
+                            "inboundTag": [
+                                ib["inbound"]["tag"] for ib in active_inbounds
+                            ],
+                            "domain": warp_domains,
+                            "outboundTag": "warp0",
+                        }
+                    )
+            else:
+                self.xray_config["routing"]["domainStrategy"] = "IPOnDemand"
 
-            for i, ib in enumerate(active_inbounds):
-                tag = ib["inbound"]["tag"]
-                self.xray_config["routing"]["rules"].insert(
-                    i,
-                    {
-                        "inboundTag": [tag],
-                        "outboundTag": f"warp{i}",
-                    },
-                )
-
-            for i, warp in enumerate(self.warps):
-                self.xray_config["outbounds"].append(
-                    {
-                        "tag": f"warp{i}",
-                        "protocol": "freedom",
-                        "settings": {"domainStrategy": "UseIPv4"},
-                        "streamSettings": {
-                            "sockopt": {"tcpFastOpen": True, "interface": f"wg{i}"}
+                for i, ib in enumerate(active_inbounds):
+                    tag = ib["inbound"]["tag"]
+                    self.xray_config["routing"]["rules"].insert(
+                        i,
+                        {
+                            "inboundTag": [tag],
+                            "outboundTag": f"warp{i}",
                         },
-                    }
-                )
+                    )
 
-            self.xray_config["outbounds"].append(
+            warp_outbounds = [
                 {
-                    "tag": "direct",
+                    "tag": f"warp{i}",
                     "protocol": "freedom",
                     "settings": {"domainStrategy": "UseIPv4"},
+                    "streamSettings": {
+                        "sockopt": {"tcpFastOpen": True, "interface": f"wg{i}"}
+                    },
                 }
+                for i in range(len(self.warps))
+            ]
+            # Unmatched traffic goes to the first outbound, so direct leads in
+            # selective mode.
+            self.xray_config["outbounds"] += (
+                [direct_outbound] + warp_outbounds
+                if selective
+                else warp_outbounds + [direct_outbound]
             )
         else:
-            self.xray_config["outbounds"].append(
-                {
-                    "tag": "direct",
-                    "protocol": "freedom",
-                    "settings": {"domainStrategy": "UseIPv4"},
-                }
-            )
+            self.xray_config["outbounds"].append(direct_outbound)
 
         self.xray_config["outbounds"] += [
             {"tag": "blocked", "protocol": "blackhole", "settings": {}}

--- a/xray/entrypoint.sh
+++ b/xray/entrypoint.sh
@@ -21,7 +21,7 @@ exit 0
 EOF
 chmod +x /usr/sbin/resolvconf
 
-if [ "$XRAY_OUTBOUND" = "warp" ]; then
+if [ "$XRAY_OUTBOUND" = "warp" ] || [ "$XRAY_OUTBOUND" = "warp-selective" ]; then
   # xray-config upstream URL for WireGuard configs
   WG_CONFIGS_URL="http://xray-config:5000/wg-configs"
 


### PR DESCRIPTION
Closes https://github.com/compassvpn/agent/issues/130. Today `XRAY_OUTBOUND` is all or nothing: either everything goes direct, or a whole inbound goes through WARP. This adds a middle option for services that don't like data-center IPs.

```
XRAY_OUTBOUND=warp-selective
WARP_DOMAINS=claude.ai,gemini.google.com,geosite:spotify
```

Registers one WARP (not one per inbound) and sends only those domains through it. Empty `WARP_DOMAINS` warns and falls back to direct.

Two ordering details:

- the rule is appended, so the existing block rules (private, bittorrent, .ir, malware) are still checked first and win
- `direct` is listed as the first outbound in this mode, since xray sends unmatched traffic to whichever outbound comes first

Full-warp mode is untouched.

Heads up, unrelated to this PR: full-warp inserts its rules *above* the block rules, so with `XRAY_OUTBOUND=warp` bittorrent and malware blocking is currently skipped. Looks like a bug, happy to do it in a separate PR.

Not live-tested yet.